### PR TITLE
docs(spec): bootstrap design for extracting IRCd from culture

### DIFF
--- a/.claude/skills.local.yaml.example
+++ b/.claude/skills.local.yaml.example
@@ -1,0 +1,12 @@
+# Per-machine config for vendored skills. Copy to skills.local.yaml (gitignored)
+# and adjust paths to match your local checkout layout.
+#
+# Used by .claude/skills/pr-review/scripts/workflow.sh delta to dump each
+# sibling project's CLAUDE.md / culture.yaml when this PR touches
+# alignment-relevant files (CLAUDE.md, .claude/skills/).
+
+# Paths are resolved relative to this repo's root. Use ../<sibling> when the
+# sibling is a peer directory; absolute paths work but break portability.
+sibling_projects:
+  - ../culture
+  - ../steward

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pr-review
+description: >
+  PR workflow for agentirc: branch, commit, push, PR, wait for Qodo/Copilot,
+  triage, fix, reply, resolve. Includes a portability lint (no absolute /home
+  paths, no per-user dotfile refs in committed docs) and an alignment-delta
+  check when CLAUDE.md or anything under .claude/skills/ changes. Use when:
+  creating PRs, handling review feedback, or the user says "create PR",
+  "review comments", "address feedback", "resolve threads".
+---
+
+# PR Review — agentirc edition
+
+Vendored from `../steward/.claude/skills/pr-review/` per
+`docs/steward/onboarding.md`. Re-sync explicitly when steward updates upstream
+— there is no auto-sync.
+
+agentirc's PRs touch the bootstrap spec, `CLAUDE.md`, vendored skills, and
+(post-bootstrap) the IRCd server core. Two recurring bug classes the generic
+`pr-review` skills miss:
+
+- **Path leaks** — committing absolute home-directory paths that work only on
+  the author's machine.
+- **Per-user config dependencies** — referencing a dotfile under the user's
+  home directory in repo guidance, breaking reproducibility for other
+  contributors and CI.
+
+Both are caught by `scripts/portability-lint.sh`. The full workflow is
+encapsulated in `scripts/workflow.sh` — follow that, not a manual checklist.
+
+## Prerequisites
+
+Hard requirements: `gh` (GitHub CLI), `jq`, `bash`, `python3` (stdlib only),
+`curl` (used by `pr-status.sh`).
+
+Per-machine paths (sibling-project layout) live in
+`.claude/skills.local.yaml`; see the committed `.example` for the schema.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `workflow.sh lint` | Portability lint on the current diff (staged + unstaged). |
+| `workflow.sh poll <PR>` | Fetch and display all review comments. |
+| `workflow.sh delta` | Dump each sibling project's `CLAUDE.md` head + `culture.yaml`. |
+| `workflow.sh reply <PR>` | Batch reply (JSONL on stdin) and resolve threads. |
+| `workflow.sh help` | Print this list. |
+
+The single-comment helpers — `pr-reply.sh`, `pr-status.sh` — live next to
+`workflow.sh` and are usable directly when batching isn't appropriate.
+
+## End-to-end flow
+
+```text
+git checkout -b <type>/<desc>
+# ... edit ...
+.claude/skills/pr-review/scripts/workflow.sh lint
+git commit -am "..." && git push -u origin <branch>
+gh pr create --title "..." --body "..."   # title <70 chars, body signed "- Claude"
+sleep 300                                  # wait for Qodo + Copilot
+.claude/skills/pr-review/scripts/workflow.sh poll <PR>
+# triage; if CLAUDE.md / .claude/skills changed:
+.claude/skills/pr-review/scripts/workflow.sh delta
+# fix, re-lint, push
+.claude/skills/pr-review/scripts/workflow.sh reply <PR> < replies.jsonl
+gh pr checks <PR>
+# Wait for human merge — never merge yourself.
+```
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`, `skill/<name>`.
+Commit/PR signature: `- Claude` (workspace convention). The reply script
+auto-appends `- Claude` only if the body isn't already signed, so JSONL
+entries can include or omit it.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid — recurring bug
+class), test or doc requests, style nits aligned with workspace conventions,
+and inconsistencies the reviewer catches between spec sections.
+
+Default to **PUSHBACK** for: architecture opinions that conflict with
+`CLAUDE.md` or the bootstrap spec; greenfield false-positives (e.g. "add
+tests" before there's any source — defer to a later PR with a clear note,
+don't refuse).
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md` or anything under `.claude/skills/`, run
+`workflow.sh delta` **before** declaring FIX or PUSHBACK on each comment.
+The script dumps the head of every sibling project's `CLAUDE.md` plus the
+full `culture.yaml`, using `sibling_projects` from `skills.local.yaml`.
+agentirc's siblings are `culture` and `steward` — note any sibling that
+needs a follow-up PR and mention it in your reply.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps are
+conditional and currently no-op (greenfield repo until the bootstrap lands):
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && bump_version_per_project_convention
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+Revisit each line as the corresponding stack element actually lands during
+or after the bootstrap.
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. Always pass `--resolve`
+when batch-replying so threads close automatically. Reference the
+review-comment IDs in the fix-up commit message. agentirc currently has no
+SonarCloud project and isn't a registered mesh agent, so skip the
+sonarclaude check and the post-merge IRC ping that culture's `pr-review`
+includes — those will return when agentirc joins those systems (the
+`sonarclaude` skill is on the steward-onboarding vendoring queue).
+
+## All-backends rule
+
+agentirc has no agent backends, so the all-backends rule that culture
+enforces does not apply here. If a comment cites it, push back.

--- a/.claude/skills/pr-review/scripts/portability-lint.sh
+++ b/.claude/skills/pr-review/scripts/portability-lint.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR.
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map from every comment ID in every thread → its thread metadata,
+# so replies in a thread also show resolved status (not just the first comment).
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] as $t | $t.comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Append signature only if the body isn't already signed.
+if ! printf '%s' "$BODY" | grep -qE '(^|\n)[[:space:]]*-[[:space:]]+Claude[[:space:]]*$'; then
+    BODY="${BODY}
+
+- Claude"
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/pr-review/scripts/pr-status.sh
+++ b/.claude/skills/pr-review/scripts/pr-status.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for a PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${REPO%%/*}_${REPO##*/}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "(For full comment bodies: bash \"$SCRIPT_DIR/pr-comments.sh\" $PR_NUMBER)"

--- a/.claude/skills/pr-review/scripts/workflow.sh
+++ b/.claude/skills/pr-review/scripts/workflow.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# pr-review workflow entry point.
+#
+# Subcommands:
+#   lint              run the portability lint on the current diff (staged + unstaged)
+#   poll <PR>         fetch and display review comments
+#   reply <PR>        batch reply to review comments (JSONL on stdin), --resolve
+#   delta             dump CLAUDE.md head + culture.yaml for each sibling project
+#                     listed in skills.local.yaml (alignment-delta check)
+#   help              print this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML list from CFG. Schema is intentionally tiny:
+#   <key>:
+#     - item
+#     - item
+# Stops at the next top-level key. No PyYAML dependency.
+read_list() {
+    awk -v key="$1" '
+        function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+        {
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+        }
+        in_list && line ~ /^[[:space:]]*-[[:space:]]*/ {
+            item = line
+            sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+            item = trim(item)
+            sub(/^["\047]/, "", item); sub(/["\047]$/, "", item)
+            if (item != "") print item
+            next
+        }
+        in_list && line ~ /^[^[:space:]#]/ { exit }
+        line ~ ("^" key ":[[:space:]]*($|#)") { in_list = 1 }
+    ' "$CFG"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        bash "$SCRIPT_DIR/portability-lint.sh"
+        ;;
+    poll)
+        PR="${1:?Usage: workflow.sh poll <PR>}"
+        bash "$SCRIPT_DIR/pr-comments.sh" "$PR"
+        ;;
+    reply)
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        bash "$SCRIPT_DIR/pr-batch.sh" --resolve "$PR"
+        ;;
+    delta)
+        any=0
+        while IFS= read -r sibling; do
+            [ -z "$sibling" ] && continue
+            any=1
+            sibling_abs="$REPO_ROOT/$sibling"
+            if [ ! -d "$sibling_abs" ] && [ ! -d "$sibling" ]; then
+                echo "=== $sibling ==="
+                echo "(not present on disk — skipped)"
+                continue
+            fi
+            target="$sibling_abs"
+            [ -d "$target" ] || target="$sibling"
+            echo "=== $target ==="
+            if [ -f "$target/CLAUDE.md" ]; then
+                head -40 "$target/CLAUDE.md"
+                echo "..."
+            else
+                echo "(no CLAUDE.md)"
+            fi
+            echo "--- culture.yaml ---"
+            if [ -f "$target/culture.yaml" ]; then
+                cat "$target/culture.yaml"
+            else
+                echo "(no culture.yaml)"
+            fi
+            echo
+        done < <(read_list sibling_projects)
+        [ "$any" -eq 0 ] && echo "(no sibling_projects configured in $CFG)"
+        ;;
+    help|--help|-h)
+        sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: Publish to PyPI
+
+# Publishes the `agentirc-cli` distribution to PyPI on push to main, and to
+# TestPyPI as `0.1.X.dev<run>` on PRs that touch the package.
+#
+# Trusted Publishing must be configured on PyPI/TestPyPI for this repo before
+# the first publish actually succeeds. Pre-bootstrap (no pyproject.toml), all
+# jobs are skipped.
+#
+# NOTE: Until culture's cutover lands (Track A in the bootstrap spec), culture
+# squat-publishes `agentirc-cli` and `agentirc` from its own publish.yml. This
+# workflow assumes culture has already removed the `agentirc-cli` alias before
+# we attempt our first 0.1.0 release; coordinate via the Track-A PR.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentirc/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentirc/**"
+
+jobs:
+  test:
+    if: hashFiles('pyproject.toml') != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run pytest -n auto -v
+
+  test-publish:
+    if: github.event_name == 'pull_request' && hashFiles('pyproject.toml') != ''
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Set dev version
+        run: |
+          BASE=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+
+      - name: Build and publish agentirc-cli to TestPyPI
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
+
+      - name: Print install commands
+        if: always()
+        run: |
+          echo "::notice::Test with: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ agentirc-cli==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push' && hashFiles('pyproject.toml') != ''
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Build and publish agentirc-cli to PyPI
+        run: |
+          uv build
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,33 @@ on:
     paths:
       - "pyproject.toml"
       - "agentirc/**"
+      - ".github/workflows/publish.yml"
   pull_request:
     branches: [main]
     paths:
       - "pyproject.toml"
       - "agentirc/**"
+      - ".github/workflows/publish.yml"
+  workflow_dispatch:
 
 jobs:
+  guard:
+    # Always passes; reports whether the package skeleton exists yet so the
+    # workflow shows a green check pre-bootstrap instead of "no jobs ran".
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Bootstrap status
+        run: |
+          if [ -f pyproject.toml ]; then
+            echo "::notice::pyproject.toml present — publish jobs will run."
+          else
+            echo "::notice::Pre-bootstrap (no pyproject.toml) — publish jobs intentionally skipped."
+          fi
+
   test:
     if: hashFiles('pyproject.toml') != ''
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,52 +1,47 @@
 name: Publish to PyPI
 
-# Publishes the `agentirc-cli` distribution to PyPI on push to main, and to
-# TestPyPI as `0.1.X.dev<run>` on PRs that touch the package.
+# Trusted Publishing release of `agentirc-cli`. Pre-bootstrap, the publish
+# steps are no-ops; once the bootstrap PR adds pyproject.toml, they activate.
 #
 # Trusted Publishing must be configured on PyPI/TestPyPI for this repo before
-# the first publish actually succeeds. Pre-bootstrap (no pyproject.toml), all
-# jobs are skipped.
+# the first real publish.
 #
 # NOTE: Until culture's cutover lands (Track A in the bootstrap spec), culture
-# squat-publishes `agentirc-cli` and `agentirc` from its own publish.yml. This
-# workflow assumes culture has already removed the `agentirc-cli` alias before
-# we attempt our first 0.1.0 release; coordinate via the Track-A PR.
+# squat-publishes `agentirc-cli` from its own publish.yml. This workflow
+# assumes culture has already removed the `agentirc-cli` alias before we
+# attempt our first 0.1.0 release.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "pyproject.toml"
-      - "agentirc/**"
-      - ".github/workflows/publish.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "pyproject.toml"
-      - "agentirc/**"
-      - ".github/workflows/publish.yml"
   workflow_dispatch:
 
 jobs:
   guard:
-    # Always passes; reports whether the package skeleton exists yet so the
-    # workflow shows a green check pre-bootstrap instead of "no jobs ran".
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      ready: ${{ steps.bootstrap.outputs.ready }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Bootstrap status
+        id: bootstrap
         run: |
           if [ -f pyproject.toml ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
             echo "::notice::pyproject.toml present — publish jobs will run."
           else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Pre-bootstrap (no pyproject.toml) — publish jobs intentionally skipped."
           fi
 
   test:
-    if: hashFiles('pyproject.toml') != ''
+    needs: guard
+    if: needs.guard.outputs.ready == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,8 +57,8 @@ jobs:
       - run: uv run pytest -n auto -v
 
   test-publish:
-    if: github.event_name == 'pull_request' && hashFiles('pyproject.toml') != ''
-    needs: test
+    needs: [guard, test]
+    if: github.event_name == 'pull_request' && needs.guard.outputs.ready == 'true'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -84,21 +79,20 @@ jobs:
           DEV_VERSION="${BASE}.dev${{ github.run_number }}"
           sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
           echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
-          echo "Publishing ${DEV_VERSION} to TestPyPI"
 
       - name: Build and publish agentirc-cli to TestPyPI
         run: |
           uv build
           uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
 
-      - name: Print install commands
+      - name: Print install command
         if: always()
         run: |
           echo "::notice::Test with: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ agentirc-cli==${DEV_VERSION}"
 
   publish:
-    if: github.event_name == 'push' && hashFiles('pyproject.toml') != ''
-    needs: test
+    needs: [guard, test]
+    if: github.event_name == 'push' && needs.guard.outputs.ready == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,83 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    # Skipped pre-bootstrap (no pyproject.toml). Runs once the bootstrap PR
+    # lands the package skeleton.
+    if: hashFiles('pyproject.toml') != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run pytest -n auto --cov=agentirc --cov-report=xml:coverage.xml --cov-report=term -v
+
+  version-check:
+    # Skipped pre-bootstrap (no pyproject.toml on main yet).
+    if: hashFiles('pyproject.toml') != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch origin main
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Check if code changed
+        id: changes
+        run: |
+          CODE_CHANGED=$(git diff --name-only origin/main...HEAD -- 'agentirc/' 'pyproject.toml' 'tests/' | head -1)
+          if [ -z "$CODE_CHANGED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Only docs/config changed — skipping version check"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check version bump
+        if: steps.changes.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAIN_VERSION=$(git show origin/main:pyproject.toml | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])")
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            MARKER="<!-- version-check -->"
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Run \`/version-bump patch\` (or minor/major) before merging to avoid a failed PyPI publish.
+
+          $MARKER"
+
+            EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
+
+            if [ -n "$EXISTING" ]; then
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING \
+                -X PATCH -f body="$BODY" > /dev/null
+            else
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
+            fi
+
+            echo "::error::Version $PR_VERSION matches main. Bump before merging."
+            exit 1
+          else
+            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   lint:
-    # Always runs. Currently exercises only the vendored portability lint;
-    # markdownlint and pre-commit hooks land alongside their config files
-    # during the bootstrap.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,26 +20,40 @@ jobs:
         run: bash .claude/skills/pr-review/scripts/portability-lint.sh --all
 
   test:
-    # Skipped pre-bootstrap (no pyproject.toml). Runs once the bootstrap PR
-    # lands the package skeleton.
-    if: hashFiles('pyproject.toml') != ''
+    needs: lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Bootstrap status check
+        id: bootstrap
+        run: |
+          if [ -f pyproject.toml ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Pre-bootstrap (no pyproject.toml) — pytest skipped."
+          fi
+
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        if: steps.bootstrap.outputs.ready == 'true'
 
-      - run: uv python install 3.12
+      - name: Install Python
+        if: steps.bootstrap.outputs.ready == 'true'
+        run: uv python install 3.12
 
-      - run: uv sync
+      - name: Sync deps
+        if: steps.bootstrap.outputs.ready == 'true'
+        run: uv sync
 
-      - run: uv run pytest -n auto --cov=agentirc --cov-report=xml:coverage.xml --cov-report=term -v
+      - name: Run tests
+        if: steps.bootstrap.outputs.ready == 'true'
+        run: uv run pytest -n auto --cov=agentirc --cov-report=xml:coverage.xml --cov-report=term -v
 
   version-check:
-    # Skipped pre-bootstrap (no pyproject.toml on main yet).
-    if: hashFiles('pyproject.toml') != ''
+    needs: lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -52,25 +63,37 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Bootstrap status check
+        id: bootstrap
+        run: |
+          if [ -f pyproject.toml ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Pre-bootstrap (no pyproject.toml) — version check skipped."
+          fi
+
       - run: git fetch origin main
+        if: steps.bootstrap.outputs.ready == 'true'
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        if: steps.bootstrap.outputs.ready == 'true'
         with:
           python-version: "3.12"
 
       - name: Check if code changed
         id: changes
+        if: steps.bootstrap.outputs.ready == 'true'
         run: |
           CODE_CHANGED=$(git diff --name-only origin/main...HEAD -- 'agentirc/' 'pyproject.toml' 'tests/' | head -1)
           if [ -z "$CODE_CHANGED" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Only docs/config changed — skipping version check"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check version bump
-        if: steps.changes.outputs.skip != 'true'
+        if: steps.bootstrap.outputs.ready == 'true' && steps.changes.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -78,23 +101,19 @@ jobs:
           MAIN_VERSION=$(git show origin/main:pyproject.toml | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])")
 
           if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
-            MARKER="<!-- version-check -->"
-            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Run \`/version-bump patch\` (or minor/major) before merging to avoid a failed PyPI publish.
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Run \`/version-bump patch\` (or minor/major) before merging.
 
-          $MARKER"
+          <!-- version-check -->"
 
             EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
               --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
 
             if [ -n "$EXISTING" ]; then
-              gh api repos/${{ github.repository }}/issues/comments/$EXISTING \
-                -X PATCH -f body="$BODY" > /dev/null
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING -X PATCH -f body="$BODY" > /dev/null
             else
               gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
             fi
 
             echo "::error::Version $PR_VERSION matches main. Bump before merging."
             exit 1
-          else
-            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,25 @@ name: Tests
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
+  lint:
+    # Always runs. Currently exercises only the vendored portability lint;
+    # markdownlint and pre-commit hooks land alongside their config files
+    # during the bootstrap.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Portability lint (full tree)
+        run: bash .claude/skills/pr-review/scripts/portability-lint.sh --all
+
   test:
     # Skipped pre-bootstrap (no pyproject.toml). Runs once the bootstrap PR
     # lands the package skeleton.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Per-machine skill config (vendored skills). Commit `.example` only.
+.claude/skills.local.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,25 @@ CLI verbs: `serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `versi
 Copy these from culture rather than inventing fresh:
 
 - `.pre-commit-config.yaml`
-- GitHub Actions workflows
 - Dev-dep set: `pytest`, `pytest-asyncio`, `pytest-xdist`, `black`, `isort`, `flake8`, `pylint`, `bandit`
 - `/version-bump` workflow and `CHANGELOG.md` style. Start the changelog at `0.1.0`.
 
-Markdown linting follows the workspace global config (`~/.markdownlint-cli2.yaml`).
+GitHub Actions workflows are already in `.github/workflows/`:
+
+- `tests.yml` — pytest with coverage on `agentirc/`, plus a version-bump check that nags via PR comment if `pyproject.toml` matches main.
+- `publish.yml` — Trusted-Publishing release of `agentirc-cli` to TestPyPI on PRs (`0.1.X.dev<run>`) and to PyPI on push to main.
+
+Both jobs are gated on `hashFiles('pyproject.toml') != ''` so they no-op cleanly during the pre-bootstrap window.
+
+Markdown linting follows the user's global markdownlint config (no committed `.markdownlint-cli2.yaml` in this repo yet).
+
+## Skills (vendored from steward)
+
+Per `docs/steward/onboarding.md`, agent skills live under `.claude/skills/<name>/`, vendored cite-don't-import from `../steward/.claude/skills/<name>/`. Already vendored:
+
+- `pr-review` — branch / commit / push / PR / wait for Qodo+Copilot / triage / fix / reply / resolve. Includes a portability lint (run via `.claude/skills/pr-review/scripts/workflow.sh lint`) and an alignment-delta check for sibling-project drift.
+
+Per-machine paths for these skills go in `.claude/skills.local.yaml` (gitignored). The committed `.claude/skills.local.yaml.example` documents the schema. When upstream skills change, re-sync explicitly — there is no auto-sync.
 
 ## Coordination with culture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Current state: pre-bootstrap
+
+This repo is being bootstrapped from a server-core extraction out of the sibling project [`culture`](https://github.com/OriNachum/culture). At the moment it contains only `LICENSE`, `README.md`, `.gitignore`, and `docs/superpowers/specs/2026-04-30-bootstrap-design.md` — no Python package, no tests, no `pyproject.toml` yet. **Read the bootstrap spec before doing anything else**; it is the operative source of truth and is intentionally self-contained.
+
+The culture-side counterpart spec is at `../culture/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`. You should not need to open it to act, but it explains the *why* if a decision in the agentirc spec looks arbitrary.
+
+## Three names, one project
+
+There are three different names in play. Don't conflate them:
+
+| Role | Name |
+|---|---|
+| PyPI distribution | `agentirc-cli` (the squatted `agentirc` on TestPyPI is **not** ours; use `agentirc-cli` everywhere) |
+| Python import package | `agentirc` |
+| CLI binary | `agentirc` |
+
+`pyproject.toml` will declare `name = "agentirc-cli"` and `[project.scripts] agentirc = "agentirc.cli:main"`.
+
+## What lives here vs. in culture
+
+- **Server-core (here):** `ircd.py`, `server_link.py`, `channel.py`, `config.py`, `events.py`, the stores (`room_store`, `thread_store`, `history_store`), `rooms_util.py`, `skill.py`, and the `skills/` directory (`rooms`, `threads`, `history`, `icon`).
+- **Stays in culture:** `client.py`, `remote_client.py`, and any test that exercises the IRC *client transport* rather than the server.
+- **Newly created here:** `agentirc/cli.py` (extracted from `../culture/culture/cli/server.py`), `agentirc/__main__.py`, and `agentirc/protocol.py` (consolidates verb names, numerics, and extension tag names that today are inlined as string literals in `ircd.py` / `client.py`).
+
+When migrating tests, the rule is: pure server tests come here, transport tests stay in culture, mixed tests stay in culture and get rewritten to drive `agentirc serve` as a subprocess fixture rather than importing `IRCd` directly. When unsure, **prefer copying the test here** — this repo owns the IRCd.
+
+## Public API contract (semver-tracked)
+
+Only three modules are public. Everything else is internal and may be refactored without a major bump.
+
+| Module | Members |
+|---|---|
+| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec` |
+| `agentirc.cli` | `main()`, `dispatch(argv) -> int` |
+| `agentirc.protocol` | verb name constants, numeric reply codes, extension tag names |
+
+`agentirc.cli.dispatch(argv)` is the function `culture`'s `culture server` shim calls — it must accept the exact same flag set, exit codes, and stderr formatting that `culture server` produces today. Do not "improve" CLI ergonomics during the bootstrap; that breaks the transparency contract culture relies on.
+
+## Defaults preserve culture continuity
+
+- Default `--config` path: `~/.culture/server.yaml` (yes, `.culture/`, not `.agentirc/`).
+- Socket paths, log paths, systemd unit names: unchanged from culture.
+- Standalone (non-culture) users override via `--config`.
+
+Do not rename on-disk artifacts during the bootstrap. That is explicitly out of scope.
+
+## Hard invariants
+
+- **No imports back into culture.** After the bootstrap, `git grep -E '^(from|import) culture' agentirc/ tests/` must return nothing. CI should enforce this.
+- **No file rewrites in the bootstrap.** Files copy from `../culture/culture/agentirc/` as-is, with import paths rewritten (`from culture.agentirc.X` → `from agentirc.X`) and nothing else. Improvements ship in follow-up PRs.
+- **Single synthetic first commit.** Message format: `Initial import from culture@<SHA>` where `<SHA>` is the culture commit ID the caller provides. No cherry-picked history.
+
+## Common commands (post-bootstrap)
+
+These will exist once the bootstrap tasks are done — they don't work yet.
+
+```bash
+# Dev setup
+uv venv && uv pip install -e ".[dev]"
+
+# Tests (the spec mandates parallel)
+pytest -n auto
+
+# Run a single test
+pytest tests/path/to/test_file.py::test_name -v
+
+# CLI smoke
+agentirc --help
+agentirc serve --config ~/.culture/server.yaml
+python -m agentirc serve   # equivalent
+```
+
+CLI verbs (1:1 with today's `culture server …`): `serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `version`.
+
+## Tooling conventions (mirror culture)
+
+Copy these from culture rather than inventing fresh:
+
+- `.pre-commit-config.yaml`
+- GitHub Actions workflows
+- Dev-dep set: `pytest`, `pytest-asyncio`, `pytest-xdist`, `black`, `isort`, `flake8`, `pylint`, `bandit`
+- `/version-bump` workflow and `CHANGELOG.md` style. Start the changelog at `0.1.0`.
+
+Markdown linting follows the workspace global config (`~/.markdownlint-cli2.yaml`).
+
+## Coordination with culture
+
+- This is **Track B** of a two-repo split. **Track A** is culture-side and is the culture agent's job — do not edit culture from this repo.
+- After `agentirc-cli==0.1.0` is on PyPI, report the published version and source SHA back so culture's cutover PR can pin against it.
+- Culture's *all-backends rule* (a feature added to one of `claude`/`codex`/`copilot`/`acp` must be propagated to the others) does **not** apply inside this repo — agentirc has no backends. It is mentioned in the spec only so future cross-repo changes account for it.
+
+## Acceptance criteria for the bootstrap
+
+The full list lives in §"Acceptance criteria" of the bootstrap spec. The non-obvious ones:
+
+- `pip install agentirc-cli==0.1.0` on a clean venv produces a working `agentirc` binary.
+- `agentirc serve` is byte-indistinguishable from `culture server start` (same socket, same logs, same systemd integration).
+- `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, `agentirc.protocol.*` all import from a clean Python session.
+- `docs/api-stability.md` names the three public modules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ agentirc serve --config ~/.culture/server.yaml
 python -m agentirc serve   # equivalent
 ```
 
-CLI verbs (1:1 with today's `culture server …`): `serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `version`.
+CLI verbs: `serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `version`. Of these, only `start`, `stop`, `status` have a `culture server …` analogue today; the rest are agentirc-only additions. Culture's pure-passthrough shim only ever emits its existing verbs, so the additions don't break it.
 
 ## Tooling conventions (mirror culture)
 

--- a/docs/steward/onboarding.md
+++ b/docs/steward/onboarding.md
@@ -1,0 +1,108 @@
+# AgentIRC alignment onboarding
+
+> Hand-written onboarding manual. Derived from steward's
+> `docs/perfect-patient.md` and `docs/sibling-pattern.md` at the time
+> this file was placed (2026-04-30). Re-read those docs in `../steward`
+> when you start a new wave of work — they evolve.
+
+This file tells the agent working in this repo what shape `agentirc`
+needs to wear once the bootstrap is done, so it can plan its skills and
+tasks against a known target. It does **not** override the bootstrap
+spec — that comes first.
+
+## Order of operations
+
+1. **Bootstrap first.** Follow `docs/superpowers/specs/2026-04-30-bootstrap-design.md` and `CLAUDE.md` until `pip install agentirc-cli==0.1.0` produces a working `agentirc` binary and `agentirc serve` is byte-indistinguishable from `culture server start`. Nothing in this onboarding doc supersedes that.
+2. **Sibling-pattern compliance.** Once the package, tests, and CI exist, work through the artifact checklist below until `steward doctor ../agentirc` passes.
+3. **Vendor skills.** Copy in the recommended skills (next section), one PR per skill, smallest blast radius first (`version-bump`, `run-tests`, `pr-review`).
+4. **Self-audit.** Run `steward doctor` (single-repo mode) after each landed PR. Treat findings as a queue.
+
+## Skill manifest
+
+`agentirc` has no agent backends, so the all-backends rule does not
+apply here. It still needs the steward-curated skill set so the repo
+hosts the same agent affordances every other sibling does.
+
+Each skill is **vendored** (cite-don't-import). Copy the directory from
+the upstream repo into `.claude/skills/<name>/` here, and only adjust
+what the local repo actually requires (project name, coverage source,
+etc.). When upstream changes, re-sync explicitly — there is no auto-sync.
+
+### Recommended (build these)
+
+Land these in roughly this order. The first three unblock the rest of
+the workflow (you can't open clean PRs without `version-bump` and
+`pr-review`, and you shouldn't claim "tests pass" without `run-tests`).
+
+| Skill | Upstream | Purpose | Notes for agentirc |
+|---|---|---|---|
+| `version-bump` | `../steward/.claude/skills/version-bump/` | Bump semver in `pyproject.toml`, prepend Keep-a-Changelog entry. Required on every PR. | Pure Python, no per-repo customization needed. Start the changelog at `0.1.0` (per CLAUDE.md). |
+| `run-tests` | `../steward/.claude/skills/run-tests/` | `pytest -n auto` with coverage. | Coverage source resolves from `[tool.coverage.run]` in `pyproject.toml`, so the script works once that section exists. |
+| `pr-review` | `../steward/.claude/skills/pr-review/` | Branch → commit → push → PR → wait for automated reviewers → triage / fix / reply / resolve threads. | Steward owns the canonical workflow. Includes the portability lint that `steward doctor` also runs. |
+| `gh-issues` | `../steward/.claude/skills/gh-issues/` | Fetch GitHub issues with full body + comments via `gh`. | Auto-detects the repo. |
+| `notebooklm` | `../steward/.claude/skills/notebooklm/` | Generate GitHub blob URLs for repo docs (NotebookLM ingestion). | Auto-detects branch + remote. |
+| `sonarclaude` | `../steward/.claude/skills/sonarclaude/` | Query SonarCloud — quality gate, issues, hotspots, metrics. Supports `accept` flow with mandatory rationale. | Set `$SONAR_PROJECT` once the project is registered, or pass `--project KEY`. |
+| `pypi-maintainer` | `../steward/.claude/skills/pypi-maintainer/` | Switch a PyPI install between production / TestPyPI dev builds / local editable checkout. | Required because this repo publishes a package and PR builds go to TestPyPI as `.dev<run>`. |
+
+### Optional (vendor if/when needed)
+
+- `discord-notify` — Discord webhook embed (info / status / completion / error). Useful if long-running tasks here ever need to page the user. Requires `DISCORD_WEBHOOK_URL`. Upstream: `../steward/.claude/skills/discord-notify/`.
+
+### Conditional (do **not** vendor)
+
+- `jekyll-test` — Conditional on the repo containing a `_config.yml`. **`agentirc` does not ship a Jekyll site, so skip this.** If that ever changes, vendor from `../steward/.claude/skills/jekyll-test/`.
+
+### Steward-specific (do **not** vendor)
+
+- `agent-config` — Resolves Culture agent suffixes; coupled to steward's own layout.
+- `doc-test-alignment` — Stub upstream; not portable yet.
+
+## Artifact checklist (sibling-pattern)
+
+The full source of truth is `../steward/docs/sibling-pattern.md`. The
+table below is a snapshot — when in doubt, defer to that file.
+
+| # | Artifact | Path | Status here |
+|---|---|---|---|
+| 1 | Toolchain | `pyproject.toml` (hatchling, Python ≥3.12, minimal runtime deps) | **TODO** (bootstrap creates it) |
+| 2 | Top-level package | `agentirc/__init__.py`, `agentirc/__main__.py`; `__version__` via `importlib.metadata("agentirc-cli")` | **TODO** (bootstrap) |
+| 3 | CLI scaffolding | `agentirc/cli/__init__.py`, `cli/_errors.py`, `cli/_output.py`, `cli/_commands/` (afi-cli pattern) | **TODO** (bootstrap) |
+| 4 | Agent-first verbs | `cli/_commands/{learn,explain,whoami}.py` | Optional for now — bootstrap only mandates the `culture server …` verb set; treat agent verbs as a follow-up. |
+| 5 | Mutation safety | Any write verb defaults to dry-run; `--apply` to commit | Apply when adding mutating verbs. |
+| 6 | Tests | `tests/test_*.py`, `pytest-xdist`, coverage | **TODO** (bootstrap) |
+| 7 | CI | `.github/workflows/tests.yml` + `publish.yml` (Trusted Publishing) | **TODO** (bootstrap) |
+| 8 | Changelog | `CHANGELOG.md`, Keep-a-Changelog format | **TODO** — start at `0.1.0`. |
+| 9 | Skills | `.claude/skills/<name>/SKILL.md` + `scripts/` per skill | **TODO** — see Skill manifest above. |
+| 10 | Per-machine config | `.claude/skills.local.yaml.example` (committed) + `.claude/skills.local.yaml` (gitignored) | **TODO** — minimal template once a skill needs it. |
+| 11 | Lint configs | `.flake8`, `.markdownlint-cli2.yaml` (repo-local) | **TODO** — copy from `../steward` / `../culture`. |
+| 12 | `CLAUDE.md` | Project shape, build/test/publish, conventions | **Present** — extend as conventions land. |
+
+## Self-audit
+
+Once the package builds and tests run:
+
+```bash
+# Single-repo invariants (portability + skills-convention)
+steward doctor ../agentirc
+
+# JSON for piping into a TODO list
+steward doctor ../agentirc --json
+```
+
+Treat the findings list as a queue. `--apply` is not yet implemented in
+steward, so each repair is hand-driven for now (see steward's roadmap
+in its `CLAUDE.md`).
+
+When the per-target generator (`steward doctor --scope siblings`) starts
+writing into `docs/steward/steward-suggestions.md` here, that file will
+be auto-generated below a marker line — anything **above** the marker is
+hand-written and preserved. This onboarding doc is separate and is not
+touched by the generator.
+
+## What this doc is **not**
+
+- Not a substitute for the bootstrap spec.
+- Not a backend coordination contract — agentirc has no backends.
+- Not a list of features to invent. Skills here are vendored from steward, not authored from scratch. New skills land **upstream first** (in steward, when generic) and then propagate here.
+
+— Claude

--- a/docs/superpowers/specs/2026-04-30-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-30-bootstrap-design.md
@@ -3,7 +3,7 @@
 **Status:** Proposed
 **Date:** 2026-04-30
 **Owner:** Ori Nachum
-**Receiving agent:** the agent working in this repo (`../agentirc`)
+**Receiving agent:** the agent working in this repo
 
 ## Summary
 
@@ -114,20 +114,22 @@ agentirc/                          (repo root)
 - `main()` — entrypoint for the `agentirc` console script.
 - `dispatch(argv: list[str]) -> int` — the exact function culture's shim will call. Same flag set, same exit codes, same output as the binary. (Culture's `culture server <verb> <args>` becomes `dispatch([<verb>, *<args>])`. It is a pure passthrough; culture does not parse, validate, or rename any flag.)
 
-Subcommands (1:1 with `culture server …` today):
+Subcommands cover the full server lifecycle agentirc exposes. Some verbs match `culture server …` today (`start`, `stop`, `status`); the rest are agentirc-only additions. Culture's pure-passthrough shim only ever emits the verbs culture itself uses, so adding new verbs here doesn't break it — culture sees its existing verbs forwarded unchanged, while standalone agentirc users get the broader surface.
 
-| Verb | Behavior | Notes |
+| Verb | Behavior | Culture analogue |
 |---|---|---|
-| `agentirc serve [--config PATH]` | Starts the IRCd in foreground. | `--config` defaults to `~/.culture/server.yaml`. |
-| `agentirc start [--name NAME]` | Starts as a managed background service (systemd / supervisor handoff). | |
-| `agentirc stop [--name NAME]` | Stops the managed service. | |
-| `agentirc restart [--name NAME]` | Restart shortcut. | |
-| `agentirc status [--name NAME]` | Reports running state. | |
-| `agentirc link <peer> [...]` | Registers a mesh server-to-server link. | |
-| `agentirc logs [--name NAME] [-f]` | Tails service logs. | |
-| `agentirc version` | Prints agentirc version. | New verb — no culture analogue. |
+| `agentirc serve [--config PATH]` | Starts the IRCd in foreground. `--config` defaults to `~/.culture/server.yaml`. | None — agentirc-only. |
+| `agentirc start [--name NAME]` | Starts as a managed background service (systemd / supervisor handoff). | `culture server start`. |
+| `agentirc stop [--name NAME]` | Stops the managed service. | `culture server stop`. |
+| `agentirc restart [--name NAME]` | Restart shortcut. | None — agentirc-only. |
+| `agentirc status [--name NAME]` | Reports running state. | `culture server status`. |
+| `agentirc link <peer> [...]` | Registers a mesh server-to-server link. | None — culture exposes linking as flags on `start` (`--link`, `--mesh-links`). |
+| `agentirc logs [--name NAME] [-f]` | Tails service logs. | None — agentirc-only. |
+| `agentirc version` | Prints agentirc version. | None — agentirc-only. |
 
-Implementation source: extract from `../culture/culture/cli/server.py`. The verbs above are exactly the verbs `culture server` exposes today; copy the dispatch logic and the per-verb handlers, rewriting any `from culture.agentirc.X` imports to `from agentirc.X`. The original file may have culture-specific glue (e.g., reading `~/.culture/server.yaml`) — keep that glue; it's part of the transparency contract.
+Implementation source: extract from `../culture/culture/cli/server.py`. For verbs with a culture analogue, copy the dispatch logic and per-verb handlers verbatim (rewriting `from culture.agentirc.X` imports to `from agentirc.X`); preserve flags, defaults, exit codes, and output. For agentirc-only verbs, build minimal handlers consistent with the existing patterns in that file. The original file may have culture-specific glue (e.g., reading `~/.culture/server.yaml`) — keep that glue; it's part of the transparency contract.
+
+Culture-side server-management verbs that exist today but are *not* migrated here (`default`, `rename`, `archive`, `unarchive`) stay in culture's own CLI; they manage culture's per-machine server registry, which is a culture concern and not part of the IRCd extraction.
 
 ### Default behaviors that preserve transparency
 
@@ -168,7 +170,7 @@ Update `agentirc/ircd.py` and any other server file to import from `agentirc.pro
 2. **Copy server-core files** per the Inputs table. Do not modify the contents yet.
 3. **Copy `protocol/extensions/`** wholesale.
 4. **Rewrite imports** inside the new tree: `from culture.agentirc.X` → `from agentirc.X`. Run `git grep -E '^(from|import) culture' agentirc/ tests/` and confirm no matches before proceeding.
-5. **Create `agentirc/cli.py`** by extracting server-lifecycle dispatch from `../culture/culture/cli/server.py`. Expose `main()` and `dispatch(argv) -> int`. Preserve verb names, flags, defaults, exit codes, output. The default `--config` path is `~/.culture/server.yaml`.
+5. **Create `agentirc/cli.py`** by extracting server-lifecycle dispatch from `../culture/culture/cli/server.py`. Expose `main()` and `dispatch(argv) -> int`. For verbs with a culture analogue (`start`, `stop`, `status`), preserve the existing verb name, flags, defaults, exit codes, and output exactly. For agentirc-only verbs (`serve`, `restart`, `link`, `logs`, `version`), add minimal handlers in the same style. The default `--config` path is `~/.culture/server.yaml`.
 6. **Create `agentirc/__main__.py`** so `python -m agentirc` works (delegates to `agentirc.cli:main`).
 7. **Create `agentirc/protocol.py`** per "What to extract" above. Update `ircd.py` and other server files to import from it.
 8. **Sort the migrated tests** per "Test-suite migration" below. Drop tests that genuinely belong in culture (transport-focused).
@@ -183,7 +185,7 @@ Update `agentirc/ircd.py` and any other server file to import from `agentirc.pro
 14. **Verify acceptance criteria** (see below).
 15. **First commit.** Single synthetic commit, message: `Initial import from culture@<SHA>` (where `<SHA>` is the source culture commit ID provided by the caller).
 16. **Tag `v0.1.0`** and push.
-17. **Publish to PyPI as `agentirc-cli`.** (PyPI publishing is already set up in this repo's CI.)
+17. **Publish to PyPI as `agentirc-cli`.** Uses the publish workflow created in Task 10 (mirrored from culture's Trusted-Publishing setup); no additional PyPI configuration in this repo before that task.
 18. **Report back** the published version and source SHA so the culture-side cutover PR can pin against it.
 
 ## Test-suite migration
@@ -199,7 +201,8 @@ When in doubt, prefer moving tests *here* over leaving them in culture: this rep
 ## Acceptance criteria
 
 - `pip install agentirc-cli==0.1.0` from PyPI produces a working `agentirc` binary on a clean venv.
-- `agentirc serve --config ~/.culture/server.yaml` starts an IRCd that behaves indistinguishably from today's `culture server start` (same accepting socket, same log output, same systemd integration).
+- `agentirc start --config ~/.culture/server.yaml` behaves indistinguishably from today's `culture server start` (same accepting socket, same log output, same systemd integration).
+- `agentirc serve --config ~/.culture/server.yaml` runs the same IRCd in the foreground (no daemonization). No culture analogue — this is the new standalone-friendly entry point.
 - `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable from a clean Python session.
 - All tests in `tests/` pass under `pytest -n auto`.
 - `git grep -E '^(from|import) culture' agentirc/ tests/` returns nothing.

--- a/docs/superpowers/specs/2026-04-30-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-30-bootstrap-design.md
@@ -1,0 +1,236 @@
+# AgentIRC Bootstrap Design
+
+**Status:** Proposed
+**Date:** 2026-04-30
+**Owner:** Ori Nachum
+**Receiving agent:** the agent working in this repo (`../agentirc`)
+
+## Summary
+
+This repo (`agentirc`) is being bootstrapped from a server-core extraction out of the sibling project [`culture`](https://github.com/OriNachum/culture). When this design is implemented, this repo will:
+
+- Be a publishable Python package on PyPI under the **distribution name `agentirc-cli`**.
+- Expose a Python **import package named `agentirc`**.
+- Ship a **CLI binary named `agentirc`**.
+- Carry the IRCd server core (RFC 2812 base + server-to-server linking + persistence + server-side skill plugins) that today lives at `../culture/culture/agentirc/`.
+
+The first release is `v0.1.0`. Culture will pin against it as `agentirc-cli>=0.1,<0.2` and call into `agentirc.cli.dispatch(argv)` from its own `culture server` shim, so existing `culture server …` UX is preserved without culture re-implementing anything.
+
+## Naming (called out, because three names appear)
+
+| Role | Name |
+|---|---|
+| PyPI distribution name | `agentirc-cli` (TestPyPI also has the squatted `agentirc`; we use `agentirc-cli` everywhere) |
+| Python import package | `agentirc` |
+| CLI binary | `agentirc` |
+| Repo path | `../agentirc` (i.e. this repo) |
+
+## Goals
+
+- A `pip install agentirc-cli` produces a working `agentirc` binary that can run an IRCd indistinguishable from today's `culture server start`.
+- Public API surface is small, documented, and semver-stable: `agentirc.config`, `agentirc.cli`, `agentirc.protocol`. Everything else is internal.
+- Zero on-disk migration for existing culture deployments — defaults match what culture uses today.
+- Tests run under `pytest -n auto` in CI and pass on first release.
+- `git grep -E '^(from|import) culture' agentirc/ tests/` returns nothing — no leaked imports back into culture.
+
+## Non-Goals
+
+- **Rewriting** any of the moved code. Files are copied as-is (with import-path adjustments only). Any improvements to ircd/server-link/stores happen in follow-up changes, not this bootstrap.
+- **Editing culture.** This work touches only this repo. Culture's own cutover (deleting `culture/agentirc/`, adding the dependency, installing the passthrough shim) is a separate PR by the culture-side agent and is **not** part of this work.
+- **Renaming on-disk artifacts.** Default config path stays `~/.culture/server.yaml`; sockets, log paths, and `culture-*` systemd unit names stay culture-named. agentirc-the-standalone-product carries that legacy in its defaults; non-culture users override via `--config`.
+- **Preserving git history from culture.** First commit is a single synthetic "Initial import from culture@\<SHA>" with no cherry-picked history. Anyone wanting the historical context for a line uses `git log` in culture before the deletion SHA.
+- **Publishing protocol/extensions docs externally.** They live in this repo; serving them is future work.
+
+## Inputs (sources in culture, at the SHA the caller provides)
+
+The culture-side agent will provide a specific culture commit SHA at copy time. Sources are read from `../culture/`. Do **not** modify culture; read-only access.
+
+| Source | Destination |
+|---|---|
+| `../culture/culture/agentirc/ircd.py` | `agentirc/ircd.py` |
+| `../culture/culture/agentirc/server_link.py` | `agentirc/server_link.py` |
+| `../culture/culture/agentirc/channel.py` | `agentirc/channel.py` |
+| `../culture/culture/agentirc/config.py` | `agentirc/config.py` |
+| `../culture/culture/agentirc/events.py` | `agentirc/events.py` |
+| `../culture/culture/agentirc/room_store.py` | `agentirc/room_store.py` |
+| `../culture/culture/agentirc/thread_store.py` | `agentirc/thread_store.py` |
+| `../culture/culture/agentirc/history_store.py` | `agentirc/history_store.py` |
+| `../culture/culture/agentirc/rooms_util.py` | `agentirc/rooms_util.py` |
+| `../culture/culture/agentirc/skill.py` | `agentirc/skill.py` |
+| `../culture/culture/agentirc/skills/` | `agentirc/skills/` |
+| `../culture/protocol/extensions/` | `protocol/extensions/` |
+| Tests in `../culture/tests/` that import `culture.agentirc.*` and are not transport-focused | `tests/` (sort per "Test-suite migration" below) |
+
+**Do NOT copy:**
+
+- `../culture/culture/agentirc/client.py` (stays in culture)
+- `../culture/culture/agentirc/remote_client.py` (stays in culture)
+- `../culture/culture/agentirc/__main__.py` (replaced; see Tasks)
+- Any test that exercises the IRC *client* transport rather than the server. Those stay in culture.
+
+## Repo layout (target)
+
+```
+agentirc/                          (repo root)
+├── pyproject.toml                 # name = "agentirc-cli"; scripts: agentirc = "agentirc.cli:main"
+├── CHANGELOG.md                   # starts at 0.1.0
+├── README.md
+├── LICENSE                        # already present
+├── .pre-commit-config.yaml
+├── agentirc/                      (Python import package)
+│   ├── __init__.py
+│   ├── __main__.py                # python -m agentirc → agentirc.cli:main
+│   ├── cli.py                     # main(), dispatch(argv) — NEW
+│   ├── protocol.py                # verb names, numerics, extension tags — NEW
+│   ├── config.py                  # ServerConfig, LinkConfig, PeerSpec (public)
+│   ├── ircd.py
+│   ├── server_link.py
+│   ├── channel.py
+│   ├── events.py
+│   ├── room_store.py
+│   ├── thread_store.py
+│   ├── history_store.py
+│   ├── rooms_util.py
+│   ├── skill.py
+│   └── skills/
+│       ├── __init__.py
+│       ├── rooms.py
+│       ├── threads.py
+│       ├── history.py
+│       └── icon.py
+├── protocol/
+│   └── extensions/                # protocol docs — agentirc owns its protocol now
+├── tests/
+└── docs/
+    ├── api-stability.md           # public surface culture pins on
+    ├── cli.md
+    └── deployment.md
+```
+
+## CLI surface
+
+`agentirc.cli` exposes:
+
+- `main()` — entrypoint for the `agentirc` console script.
+- `dispatch(argv: list[str]) -> int` — the exact function culture's shim will call. Same flag set, same exit codes, same output as the binary. (Culture's `culture server <verb> <args>` becomes `dispatch([<verb>, *<args>])`. It is a pure passthrough; culture does not parse, validate, or rename any flag.)
+
+Subcommands (1:1 with `culture server …` today):
+
+| Verb | Behavior | Notes |
+|---|---|---|
+| `agentirc serve [--config PATH]` | Starts the IRCd in foreground. | `--config` defaults to `~/.culture/server.yaml`. |
+| `agentirc start [--name NAME]` | Starts as a managed background service (systemd / supervisor handoff). | |
+| `agentirc stop [--name NAME]` | Stops the managed service. | |
+| `agentirc restart [--name NAME]` | Restart shortcut. | |
+| `agentirc status [--name NAME]` | Reports running state. | |
+| `agentirc link <peer> [...]` | Registers a mesh server-to-server link. | |
+| `agentirc logs [--name NAME] [-f]` | Tails service logs. | |
+| `agentirc version` | Prints agentirc version. | New verb — no culture analogue. |
+
+Implementation source: extract from `../culture/culture/cli/server.py`. The verbs above are exactly the verbs `culture server` exposes today; copy the dispatch logic and the per-verb handlers, rewriting any `from culture.agentirc.X` imports to `from agentirc.X`. The original file may have culture-specific glue (e.g., reading `~/.culture/server.yaml`) — keep that glue; it's part of the transparency contract.
+
+### Default behaviors that preserve transparency
+
+- `--config` defaults to `~/.culture/server.yaml`.
+- Socket paths, log paths, systemd unit names: unchanged from current culture defaults.
+- Exit codes and stderr formatting: inherited from the moved code (no rewrites in this bootstrap).
+
+## Public API contract
+
+The **only** modules culture (and any third-party consumer) is allowed to import:
+
+| Module | Members | Stability |
+|---|---|---|
+| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
+| `agentirc.cli` | `main()`, `dispatch(argv) -> int` | Public, semver-tracked. |
+| `agentirc.protocol` | Verb name constants, numeric reply codes, extension tag names | Public, semver-tracked. |
+
+Everything else (`agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`, the stores, the skills) is internal. Document this contract in `docs/api-stability.md`. Future refactors of internals must not change `agentirc.config`, `agentirc.cli`, or `agentirc.protocol` without a semver-major bump.
+
+### `agentirc.protocol` — what to extract
+
+`protocol.py` does **not** exist in culture today. The protocol vocabulary is currently inlined as string literals in two places:
+
+- `../culture/culture/agentirc/ircd.py` — server side
+- `../culture/culture/agentirc/client.py` — client side (read-only reference; do not copy this file)
+
+Extract from both into a single `agentirc/protocol.py`:
+
+- IRC verb names (e.g., `PRIVMSG`, `JOIN`, `PART`, `MODE`, plus Culture extensions like `THREAD`, `ROOM`, history-sync verbs).
+- Numeric reply codes used by the server.
+- Extension tag names used in capability negotiation.
+
+Update `agentirc/ircd.py` and any other server file to import from `agentirc.protocol` instead of using string literals. Culture's `client.py` will be updated by the culture-side agent to do the same against this module.
+
+## Tasks (ordered)
+
+1. **Create the package skeleton.** Add `agentirc/__init__.py`, `agentirc/__main__.py`, empty `agentirc/skills/__init__.py`, the `tests/` directory, the `docs/` directory.
+2. **Copy server-core files** per the Inputs table. Do not modify the contents yet.
+3. **Copy `protocol/extensions/`** wholesale.
+4. **Rewrite imports** inside the new tree: `from culture.agentirc.X` → `from agentirc.X`. Run `git grep -E '^(from|import) culture' agentirc/ tests/` and confirm no matches before proceeding.
+5. **Create `agentirc/cli.py`** by extracting server-lifecycle dispatch from `../culture/culture/cli/server.py`. Expose `main()` and `dispatch(argv) -> int`. Preserve verb names, flags, defaults, exit codes, output. The default `--config` path is `~/.culture/server.yaml`.
+6. **Create `agentirc/__main__.py`** so `python -m agentirc` works (delegates to `agentirc.cli:main`).
+7. **Create `agentirc/protocol.py`** per "What to extract" above. Update `ircd.py` and other server files to import from it.
+8. **Sort the migrated tests** per "Test-suite migration" below. Drop tests that genuinely belong in culture (transport-focused).
+9. **Write `pyproject.toml`:**
+   - `name = "agentirc-cli"`, `version = "0.1.0"`
+   - `[project.scripts] agentirc = "agentirc.cli:main"`
+   - Mirror culture's runtime + dev dep set: pytest, pytest-asyncio, pytest-xdist, black, isort, flake8, pylint, bandit. (Take culture's `pyproject.toml` as a reference; copy the dev-dep group verbatim where applicable.)
+10. **Mirror culture's pre-commit, CI, and version workflow.** Copy `.pre-commit-config.yaml`, GitHub Actions, and `/version-bump`/CHANGELOG conventions from culture. Start `CHANGELOG.md` at `0.1.0`.
+11. **Write `docs/api-stability.md`** documenting the three public modules. Mark everything else internal.
+12. **Write minimal `docs/cli.md` and `docs/deployment.md`** that describe the CLI verbs and on-disk footprint (point users at `~/.culture/server.yaml` for defaults, with override via `--config`).
+13. **Run the test suite.** `pytest -n auto` must pass.
+14. **Verify acceptance criteria** (see below).
+15. **First commit.** Single synthetic commit, message: `Initial import from culture@<SHA>` (where `<SHA>` is the source culture commit ID provided by the caller).
+16. **Tag `v0.1.0`** and push.
+17. **Publish to PyPI as `agentirc-cli`.** (PyPI publishing is already set up in this repo's CI.)
+18. **Report back** the published version and source SHA so the culture-side cutover PR can pin against it.
+
+## Test-suite migration
+
+Tests from culture are sorted into three buckets:
+
+1. **Imports `culture.agentirc.X` only (server core)** → moves to `tests/` here.
+2. **Imports `culture.agentirc.client` / `remote_client` only** → stays in culture (transport-focused). Do not copy.
+3. **Imports both** → if the test is genuinely cross-cutting (a bot connecting to an IRCd in the same process), it stays in culture and is rewritten there to use `agentirc serve` as a subprocess fixture rather than importing `IRCd` directly. Do not copy here unless it's a pure server test that happens to construct a transport object only as a test helper — in which case adapt the test to spin its own helper.
+
+When in doubt, prefer moving tests *here* over leaving them in culture: this repo owns the IRCd, and IRCd-internal tests should run in this repo's CI.
+
+## Acceptance criteria
+
+- `pip install agentirc-cli==0.1.0` from PyPI produces a working `agentirc` binary on a clean venv.
+- `agentirc serve --config ~/.culture/server.yaml` starts an IRCd that behaves indistinguishably from today's `culture server start` (same accepting socket, same log output, same systemd integration).
+- `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable from a clean Python session.
+- All tests in `tests/` pass under `pytest -n auto`.
+- `git grep -E '^(from|import) culture' agentirc/ tests/` returns nothing.
+- `agentirc --help` lists every verb in the CLI surface table above.
+- `docs/api-stability.md` exists and names the three public modules.
+- `pyproject.toml` declares `name = "agentirc-cli"` and the `agentirc` console script.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hidden coupling: a server-core file imports `culture.X` (not `culture.agentirc.X`) and we miss it. | Step 4 of Tasks runs `git grep` for any `culture` import. CI must enforce this with a lint step on every PR. |
+| `agentirc.protocol` extraction misses a string literal. | After extraction, grep server files for IRC verb regexes (e.g. `\b(JOIN|PART|PRIVMSG|MODE|...)\b` in string contexts) to spot remaining literals. |
+| Default config path `~/.culture/server.yaml` confuses standalone (non-culture) users. | Document `--config` override clearly in `docs/cli.md` and `docs/deployment.md`. The default is a transparency choice for culture continuity, not a permanent constraint. |
+| First PyPI release is broken; culture's cutover PR can't merge. | Patches go out as `0.1.1`, `0.1.2`. Culture's PR can pin to a specific known-good `==0.1.X` until `0.1` is stable. |
+| Test bucket sorting (server vs transport) is wrong. | When unsure, put tests here. Culture's reviewer will notice if a transport test landed in the wrong repo and the fix is a follow-up move. |
+
+## Out of scope (deferred to follow-ups, not this bootstrap)
+
+- Refactoring the IRCd, stores, or skills beyond import-path edits.
+- Renaming on-disk artifacts to non-culture names.
+- Adding new protocol extensions.
+- Splitting `client.py` into its own distribution (e.g., `agentirc-client`).
+- A public docs site for `protocol/extensions/`.
+
+## Coordination with culture
+
+- This bootstrap is **Track B** in culture's spec. **Track A** (culture-side cutover PR) is owned by the culture-side agent and depends on this Track B completing first.
+- After this work merges and `agentirc-cli==0.1.0` is on PyPI, report back the version + source SHA. The culture-side agent then opens its own PR to add the dependency, delete `culture/agentirc/`, install the `culture server` passthrough, and `/version-bump major`.
+- All-backends rule (a culture convention): changes that cross the agentirc / culture-transport boundary must be reflected across all four backends in culture (`claude`, `codex`, `copilot`, `acp`). Not your concern for this bootstrap; flagged here so future cross-repo changes account for it.
+
+## Reference
+
+The culture-side spec for this split lives at `../culture/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`. This document (the agentirc bootstrap spec) is intentionally self-contained — you should not need to read the culture-side spec to act on this work. The culture spec is provided only for context if you want to understand why a decision was made.


### PR DESCRIPTION
## Summary

- Adds a self-contained bootstrap brief at `docs/superpowers/specs/2026-04-30-bootstrap-design.md` for the agent that will populate this repo with the IRCd server core extracted from [culture](https://github.com/OriNachum/culture).
- This is a planning artifact — no code, package layout, or CLI is implemented yet. The spec is the input the implementing agent works from.
- Companion to culture's spec at `culture/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (Track B in that document); culture's cutover PR (Track A) waits on the `agentirc-cli==0.1.0` PyPI release this work produces.

## Highlights

- **Naming:** distribution `agentirc-cli`, import `agentirc`, CLI binary `agentirc`.
- **Boundary:** server core (ircd, server-link, channel, config, events, stores, skill, skills) moves here. Client transport (`client.py`, `remote_client.py`) stays in culture.
- **CLI surface:** 1:1 with today's `culture server …` verbs (`serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `version`). `agentirc.cli.dispatch(argv)` is the function culture's passthrough shim will call.
- **Public API contract:** only `agentirc.config`, `agentirc.cli`, `agentirc.protocol` — semver-tracked. Everything else is internal.
- **On-disk footprint:** zero migration. Default `--config` path is `~/.culture/server.yaml`; sockets, log paths, and `culture-*` systemd units stay culture-named. Standalone users override via `--config`.
- **History:** Approach 2 — first commit is a synthetic "Initial import from culture@<SHA>", no cherry-picked history.
- New modules to create: `agentirc/cli.py` (extracted from culture's `cli/server.py`) and `agentirc/protocol.py` (verb/numeric/extension-tag constants pulled out of string literals).

## Test plan

- [ ] Spec reviewed by the agent who will execute the bootstrap, confirming the inputs/tasks/acceptance-criteria are sufficient to act without consulting culture's spec.
- [ ] No code changes in this PR — only a docs file is added; CI should be green by default.

- Claude