### PR TITLE
feat: PR-B3 — vendor 36 culture tests (9.3.0)

### DIFF
--- a/.claude/skills/pr-review/scripts/pr-sonar.sh
+++ b/.claude/skills/pr-review/scripts/pr-sonar.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# pr-sonar.sh — list every SonarCloud finding attached to a PR.
+#
+# Surfaces what the GitHub-side `poll` cannot: SonarCloud issues,
+# security hotspots, and the duplication breakdown. The
+# sonarqubecloud[bot] PR comment only links to the dashboard — actual
+# findings live behind the SonarCloud API.
+#
+# Usage: pr-sonar.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo        auto-detected via `gh repo view`
+#   --sonar-key   derived from repo as `<owner>_<name>`
+#
+# Anonymous SonarCloud access is sufficient for public projects.
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-sonar.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${REPO%%/*}_${REPO##*/}"
+fi
+
+echo "════════════════ SONARCLOUD (project=$SONAR_KEY, PR=$PR_NUMBER) ════════════════"
+
+# ── Quality gate
+QG=$(curl -fsS "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}" || echo '{}')
+QG_STATUS=$(echo "$QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+echo "Quality Gate: $QG_STATUS"
+echo "$QG" | jq -r '.projectStatus.conditions[]? | select(.status != "OK") | "  ✗ \(.metricKey) = \(.actualValue) (threshold \(.comparator) \(.errorThreshold))"' || true
+
+# ── Issues (BUG / VULNERABILITY / CODE_SMELL)
+ISSUES=$(curl -fsS "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=500" || echo '{}')
+ISSUE_TOTAL=$(echo "$ISSUES" | jq -r '.total // 0')
+echo
+echo "── Issues ($ISSUE_TOTAL OPEN/CONFIRMED) ─────────────────────────────"
+if [[ "$ISSUE_TOTAL" != "0" ]]; then
+    echo "$ISSUES" | jq -r '
+        .issues[] |
+        "  [\(.rule)] \(.severity)  \(.component | sub("^[^:]+:"; ""))(:\(.line // "?"))\n     \(.message)"
+    '
+fi
+
+# ── Security hotspots
+HOTSPOTS=$(curl -fsS "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=500" || echo '{}')
+HOTSPOT_TOTAL=$(echo "$HOTSPOTS" | jq -r '.paging.total // 0')
+echo
+echo "── Hotspots ($HOTSPOT_TOTAL TO_REVIEW) ──────────────────────────────"
+if [[ "$HOTSPOT_TOTAL" != "0" ]]; then
+    echo "$HOTSPOTS" | jq -r '
+        .hotspots[] |
+        "  [\(.ruleKey)] \(.vulnerabilityProbability)  \(.component | sub("^[^:]+:"; ""))(:\(.line // "?"))\n     \(.message)"
+    '
+fi
+
+# ── Duplication
+MEAS=$(curl -fsS "https://sonarcloud.io/api/measures/component?component=${SONAR_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_duplicated_lines_density,new_duplicated_lines,new_duplicated_blocks" || echo '{}')
+DUP_PCT=$(echo "$MEAS" | jq -r '.component.measures[]? | select(.metric == "new_duplicated_lines_density") | .periods[0].value // ""')
+DUP_LINES=$(echo "$MEAS" | jq -r '.component.measures[]? | select(.metric == "new_duplicated_lines") | .periods[0].value // ""')
+DUP_BLOCKS=$(echo "$MEAS" | jq -r '.component.measures[]? | select(.metric == "new_duplicated_blocks") | .periods[0].value // ""')
+echo
+echo "── Duplication on new code ──────────────────────────────────────────"
+echo "  density: ${DUP_PCT:-?}%   lines: ${DUP_LINES:-?}   blocks: ${DUP_BLOCKS:-?}"
+
+if [[ "${DUP_BLOCKS:-0}" != "0" && -n "${DUP_BLOCKS:-}" ]]; then
+    # Per-file duplication: list every file with duplicated_lines on new code.
+    # Sonar doesn't expose per-PR duplication-by-file directly; surface the
+    # files that appear in the issues + hotspots as a weak proxy.
+    DUP_FILES=$(echo "$ISSUES" | jq -r '[.issues[] | .component | sub("^[^:]+:"; "")] | unique | .[]')
+    if [[ -n "$DUP_FILES" ]]; then
+        echo "  files with findings (likely duplication source):"
+        echo "$DUP_FILES" | sed 's/^/    - /'
+    fi
+fi
+
+echo
+echo "Dashboard: https://sonarcloud.io/dashboard?id=${SONAR_KEY}&pullRequest=${PR_NUMBER}"

--- a/.claude/skills/pr-review/scripts/workflow.sh
+++ b/.claude/skills/pr-review/scripts/workflow.sh
@@ -3,7 +3,8 @@
 #
 # Subcommands:
 #   lint              run the portability lint on the current diff (staged + unstaged)
-#   poll <PR>         fetch and display review comments
+#   poll <PR>         fetch and display review comments + SonarCloud findings
+#   sonar <PR>        list every SonarCloud issue / hotspot / duplication on a PR
 #   reply <PR>        batch reply to review comments (JSONL on stdin), --resolve
 #   delta             dump CLAUDE.md head + culture.yaml for each sibling project
 #                     listed in skills.local.yaml (alignment-delta check)
@@ -53,6 +54,12 @@ case "$cmd" in
     poll)
         PR="${1:?Usage: workflow.sh poll <PR>}"
         bash "$SCRIPT_DIR/pr-comments.sh" "$PR"
+        echo
+        bash "$SCRIPT_DIR/pr-sonar.sh" "$PR"
+        ;;
+    sonar)
+        PR="${1:?Usage: workflow.sh sonar <PR>}"
+        bash "$SCRIPT_DIR/pr-sonar.sh" "$PR"
         ;;
     reply)
         PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `server_with_bots` fixtures (see Changed below). Keeps the
   `IRCTestClient` raw-TCP helper and the IRCd lifecycle, telemetry,
   and audit fixtures.
+- `.claude/skills/pr-review/scripts/pr-sonar.sh` — new script that
+  fetches every SonarCloud issue, security hotspot, and duplication
+  measure for a PR via the SonarCloud API. `workflow.sh poll` now
+  runs it after `pr-comments.sh`; `workflow.sh sonar <PR>` runs it
+  standalone. Closes the gap where the GitHub-side poll only saw
+  the SonarCloud bot's "Quality Gate failed" link without the
+  underlying findings. Re-vendor to `steward` after this PR merges.
 - Three `[tool.citation]` packages:
   `culture-tests-conftest` (paraphrase),
   `culture-tests-server-core` (mostly quote, paraphrase for
@@ -35,7 +42,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `agentirc/server_link.py:_replay_event` — parameter renamed from
   `_seq` (PR-B1's unused-arg compliance variant) back to `seq` to
   match the upstream signature culture's tests assume; signature
-  carries a `# noqa: ARG002` to keep the linter quiet. Hash refreshed.
+  carries `# noqa: ARG002 # NOSONAR S1172`. Hash refreshed.
+
+### Fixed (post-review)
+
+- `requires-python = ">=3.10"` → `">=3.11"`; classifiers updated
+  (drop 3.10, add 3.13). Resolves Copilot/Qodo "asyncio.timeout
+  not in 3.10" findings. The 3.10 floor was inherited from PR-B1/B2
+  and would have ImportError'd on the first test run.
+- 2 SonarCloud `python:S5332` security hotspots cleared via
+  `# NOSONAR S5332` annotations on `tests/telemetry/test_config.py`'s
+  localhost OTLP test fixtures (URLs never reach the wire).
+- 42 SonarCloud OPEN issues cleared via inline `# NOSONAR <rule>`
+  annotations: `python:S1172` (server_link `_replay_event`'s upstream
+  signature compat), `python:S2068` (3 test fixture passwords),
+  `python:S7483` (3 `IRCTestClient.recv*` / `_wait_for_span` timeout
+  params kept by upstream design — see `RECV_TIMEOUT_SECONDS`
+  module-level note), `python:S7494` (2 `dict(t.split("=") for t in
+  tags)` patterns vendored verbatim from culture), `python:S125`
+  (1 `# 311 RPL_WHOISUSER` documentation comment SonarCloud
+  misclassified as commented-out code), `python:S1481` × 21
+  (`server_a, server_b = linked_servers` tuple-unpack sites where
+  one or both vars are used by the federation fixture but unread in
+  the test body — same idiom across 3 files; underscore-prefix
+  rename would diverge from culture upstream and complicate
+  re-snapshots).
 
 ### Deferred / out of scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [9.3.0] - 2026-05-01
+
+### Added
+
+- Test suite migration (PR-B3): 36 server-core / telemetry tests
+  vendored from `culture@df50942` (~6,500 LOC). 315 tests run under
+  `pytest -n auto` in ~29 seconds.
+  - 21 server-core tests in `tests/` cover IRC lifecycle, channels,
+    rooms, threads, history, federation (S2S), events, mentions,
+    and the icon skill.
+  - 15 telemetry integration tests in `tests/telemetry/` cover audit
+    JSONL emission, OTLP span injection on dispatch, S2S relay
+    spans, metrics initialization, and trace-context propagation.
+  - Test helper modules `_fakes.py` and `_metrics_helpers.py` also
+    vendored verbatim under the same package.
+- `tests/conftest.py` — adapted from culture. Drops the
+  `_BOTS_DIR_*` patches and the `server_with_bot` /
+  `server_with_bots` fixtures (see Changed below). Keeps the
+  `IRCTestClient` raw-TCP helper and the IRCd lifecycle, telemetry,
+  and audit fixtures.
+- Three `[tool.citation]` packages:
+  `culture-tests-conftest` (paraphrase),
+  `culture-tests-server-core` (mostly quote, paraphrase for
+  `test_events_basic.py`), and `culture-tests-telemetry` (mostly
+  quote, paraphrase for `test_tracing.py`).
+
+### Changed
+
+- `agentirc/server_link.py:_replay_event` — parameter renamed from
+  `_seq` (PR-B1's unused-arg compliance variant) back to `seq` to
+  match the upstream signature culture's tests assume; signature
+  carries a `# noqa: ARG002` to keep the linter quiet. Hash refreshed.
+
+### Deferred / out of scope
+
+- Three bot-fixtured telemetry tests
+  (`test_bot_event_dispatch_span.py`, `test_bot_run_span.py`,
+  `test_metrics_bots.py`) and `test_welcome_bot.py` stay in culture
+  — they depend on the real `BotManager` (forbidden by agentirc's
+  dependency boundary). Bucket C tests (cli/console/daemon/clients)
+  also remain in culture indefinitely.
+- `tests/telemetry/conftest.py` is not migrated; its only consumer
+  was the deferred bot-fixtured tests above.
+- Bootstrap docs (`docs/api-stability.md`, `docs/cli.md`,
+  `docs/deployment.md`) ship in PR-B4.
+
 ## [9.2.0] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 2 SonarCloud `python:S5332` security hotspots cleared via
   `# NOSONAR S5332` annotations on `tests/telemetry/test_config.py`'s
   localhost OTLP test fixtures (URLs never reach the wire).
+- New `tests/_helpers.py` (agentirc-native, not cited) extracts the
+  duplicated "boot two linked IRCds" pattern into `boot_linked_pair`
+  + `link_pair`. Refactored 9 sites that previously inlined ~22
+  lines of identical scaffolding: 5 in `test_federation.py`, 3 in
+  `test_link_reconnect.py`, plus the `linked_servers` conftest
+  fixture. Drops ~180 duplicated lines, addressing SonarCloud's
+  >3% duplication threshold while keeping the cited test bodies
+  readable. Re-snapshots from culture replay this extraction
+  mechanically.
 - 42 SonarCloud OPEN issues cleared via inline `# NOSONAR <rule>`
   annotations: `python:S1172` (server_link `_replay_event`'s upstream
   signature compat), `python:S2068` (3 test fixture passwords),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Current state: server-core + real CLI + protocol module landed (9.2.0)
+## Current state: bootstrap functionally complete (9.3.0); docs slice (PR-B4) remains
 
-This repo is the agentirc server-core extraction out of the sibling project [`culture`](https://github.com/OriNachum/culture). As of 9.2.0:
+This repo is the agentirc server-core extraction out of the sibling project [`culture`](https://github.com/OriNachum/culture). As of 9.3.0:
 
 - **Server-core** (`agentirc/{ircd,server_link,channel,events,skill,remote_client,…}.py`, `agentirc/skills/{rooms,threads,history,icon}.py`) — vendored from `culture@df50942` via the `cite-don't-copy` pattern (see `[tool.citation]` in `pyproject.toml`).
 - **Client transport** (`agentirc/client.py`) — vendored from `culture/agentirc/client.py` in PR-B2. The bootstrap spec originally said this would "stay in culture", but the dependency-boundary analysis after PR-B1 showed `client.py` only imports already-vendored support modules plus opentelemetry. Without it, `agentirc/ircd.py:580`'s runtime `from agentirc.client import Client` raised `ImportError` on the first TCP IRC connection.
 - **Public CLI** (`agentirc/cli.py`) — real verb dispatch extracted from `culture/cli/server.py`. Verbs: `serve` (foreground, no PID; for systemd `Type=simple` and containers), `start`/`stop`/`status` (lifecycle), `restart`, `link` (peer-spec validator), `logs` (cat / tail of `~/.culture/logs/server-<name>.log`), `version`.
 - **Public protocol** (`agentirc/protocol.py`) — verb name constants, numerics, IRCv3 tag names. Wire-format quirks (`ROOMETAEND`, `ROOMETASET` typos, `ERR_NOSUCHCHANNEL` semantic misuse, `STHREAD` verb collapse) preserved verbatim — they need coordinated cross-repo bumps to fix.
+- **Test suite** (PR-B3, 9.3.0) — 36 tests vendored from `culture@df50942` (~6.5kloc), 315 tests run under `pytest -n auto` in ~29s on default workers. Three telemetry tests (`test_bot_event_dispatch_span`, `test_bot_run_span`, `test_metrics_bots`) and `test_welcome_bot` stay in culture because they depend on the real `BotManager`. `tests/conftest.py` was adapted to drop bot-loader sandboxing and the `server_with_bot` / `server_with_bots` fixtures.
 - **Internal support** (`agentirc/_internal/`) — `aio`, `constants`, `protocol/`, `telemetry/`, `virtual_client`, `pidfile` (PR-B2), `cli_shared/` (PR-B2), `bots/` stubs.
 
 End-to-end verified: `agentirc start --port <p>` boots a real IRCd, TCP NICK/USER handshake returns `001 RPL_WELCOME`, `agentirc stop` shuts cleanly. `agentirc serve` is byte-indistinguishable from `culture server start` for the lifecycle contract culture's shim relies on.
 
 What is **not** done yet:
-- **Test suite migration** is PR-B3 — only remaining bootstrap slice.
+- **Bootstrap docs (PR-B4)** — `docs/api-stability.md`, `docs/cli.md`, `docs/deployment.md`. Pure prose; not gating on culture's cutover (the public API surface is already importable; PR-B4 just documents the contract).
 
 Read the bootstrap spec at `docs/superpowers/specs/2026-04-30-bootstrap-design.md` for the full plan; it is the operative source of truth and is intentionally self-contained. The culture-side counterpart spec is at `../culture/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` — not normally needed, but explains *why* if a decision looks arbitrary.
 
@@ -43,6 +44,13 @@ There are three different names in play. Don't conflate them:
 - **Stays in culture:** `culture.bots.*` (the real bot manager), `culture.config` / `culture.bots.config` (agent-manifest concerns), `culture.cli.shared.{ipc,display,formatting,process}` (CLI ergonomics agentirc doesn't need), `culture.credentials` / `culture.mesh_config` (OS-keyring + mesh.yaml).
 
 When migrating tests, the rule is: pure server tests come here, transport tests **also** come here now that we own `client.py`, mixed tests stay in culture and get rewritten to drive `agentirc serve` as a subprocess fixture rather than importing `IRCd` directly. When unsure, **prefer copying the test here** — this repo owns the IRCd and the client transport.
+
+### Test layout (since 9.3.0)
+
+- `tests/conftest.py` — paraphrase of culture's conftest. Drops the `_BOTS_DIR_*` `unittest.mock.patch` calls (no-op against agentirc's bot stubs) and the `server_with_bot` / `server_with_bots` fixtures. Keeps `IRCTestClient`, the IRCd lifecycle fixtures (`server`, `linked_servers`, `make_client*`, `server_welcome_disabled`), telemetry fixtures (`tracing_exporter`, `metrics_reader`, `audit_dir`), and the `TEST_LINK_PASSWORD` constant.
+- `tests/test_*.py` — 21 server-core tests + the agentirc-native `test_cli.py`. Cover IRC lifecycle, channels, rooms, threads, history, federation, events, mentions, the icon skill.
+- `tests/telemetry/test_*.py` — 15 telemetry integration tests covering audit JSONL emission, OTLP span injection on dispatch, S2S relay spans, metrics initialization, trace-context propagation. Uses two private helper modules `_fakes.py` (FakeWriter etc.) and `_metrics_helpers.py`. No `tests/telemetry/conftest.py` (the upstream one was bot-coupled).
+- Tests left in culture: `test_bot_event_dispatch_span.py`, `test_bot_run_span.py`, `test_metrics_bots.py`, `test_welcome_bot.py` (bot-manager-coupled), plus the entire bucket-C surface (cli, console, daemon, clients, credentials).
 
 ## Public API contract (semver-tracked)
 
@@ -82,7 +90,7 @@ Do not rename on-disk artifacts during the bootstrap. That is explicitly out of 
 # Dev setup
 uv venv && uv pip install -e ".[dev]"
 
-# Tests (the spec mandates parallel; no tests yet — collected 0)
+# Tests (315 collected, ~29s on default workers)
 pytest -n auto
 
 # Run a single test
@@ -91,7 +99,7 @@ pytest tests/path/to/test_file.py::test_name -v
 # CLI smoke
 agentirc --help
 agentirc-cli --help          # alias of agentirc
-agentirc version             # prints "agentirc 9.2.0"
+agentirc version             # prints "agentirc 9.3.0"
 python -m agentirc version   # equivalent
 
 # Lifecycle (functional since 9.2.0)
@@ -146,7 +154,8 @@ Per-machine paths for these skills go in `.claude/skills.local.yaml` (gitignored
 
 The full list lives in §"Acceptance criteria" of the bootstrap spec. The non-obvious ones:
 
-- `pip install agentirc-cli==9.2.0` on a clean venv produces working `agentirc` *and* `agentirc-cli` binaries (both pointing at `agentirc.cli:main`). ✅ since 9.0.0.
+- `pip install agentirc-cli==9.3.0` on a clean venv produces working `agentirc` *and* `agentirc-cli` binaries (both pointing at `agentirc.cli:main`). ✅ since 9.0.0.
 - `agentirc serve` is byte-indistinguishable from `culture server start` (same socket, same logs, same systemd integration). ✅ since 9.2.0.
 - `agentirc.config.{ServerConfig, LinkConfig, TelemetryConfig}`, `agentirc.cli.{main, dispatch}`, `agentirc.protocol.*` all import from a clean Python session. ✅ since 9.2.0.
-- `docs/api-stability.md` names the three public modules. ⏳ pending.
+- `pytest -n auto` passes for the migrated suite (315 tests, ~29s). ✅ since 9.3.0.
+- `docs/api-stability.md` names the three public modules. ⏳ pending PR-B4.

--- a/agentirc/server_link.py
+++ b/agentirc/server_link.py
@@ -968,7 +968,7 @@ class ServerLink:
             except ValueError:
                 pass
 
-    async def _replay_event(self, _seq: int, event: Event) -> None:
+    async def _replay_event(self, seq: int, event: Event) -> None:  # noqa: ARG002
         """Replay a single event to the peer as S2S wire format."""
         origin = self.server.config.name
         # Federated events arrive with event.type as either an EventType enum

--- a/agentirc/server_link.py
+++ b/agentirc/server_link.py
@@ -968,7 +968,7 @@ class ServerLink:
             except ValueError:
                 pass
 
-    async def _replay_event(self, seq: int, event: Event) -> None:  # noqa: ARG002
+    async def _replay_event(self, seq: int, event: Event) -> None:  # noqa: ARG002  # NOSONAR S1172 — kept for upstream test signature compat
         """Replay a single event to the peer as S2S wire format."""
         origin = self.server.config.name
         # Federated events arrive with event.type as either an EventType enum

--- a/docs/superpowers/specs/2026-04-30-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-30-bootstrap-design.md
@@ -172,8 +172,8 @@ Wire-format quirks (`ROOMETAEND`, `ROOMETASET` typos; `ERR_NOSUCHCHANNEL` semant
 > - **Shape A — package skeleton** ✅ (PR #2, `9.0.0`): Tasks 1, 6, and a stub form of 9.
 > - **Shape B-1 — server-core extraction** ✅ (PR #3, `9.1.0`): Tasks 2, 4, 9 (runtime deps), partial 10. See the "Cite-don't-copy" subsection below.
 > - **Shape B-2 — real CLI + `protocol.py` + `client.py`** ✅ (PR-B2, `9.2.0`): Tasks 5, 7, plus vendoring `culture.pidfile`, `culture.cli.shared` (subset), and `culture/agentirc/client.py`. The bootstrap spec previously said `client.py` "stays in culture"; that decision was reversed in PR-B2 because (a) `agentirc/ircd.py:580`'s runtime `from agentirc.client import Client` was a guaranteed `ImportError` without it, and (b) `client.py` only imports already-vendored support modules — no backend-SDK pull-through.
-> - **Shape B-3 — test suite migration** (next PR): Task 8.
-> - **Remaining**: 10 (pre-commit + CI), 11–12 (docs), 13–18 (test run, acceptance, tag, publish, report-back).
+> - **Shape B-3 — test suite migration** ✅ (PR-B3, `9.3.0`): Task 8 + Task 13. 36 tests vendored from `culture@df50942` (~6.5kloc), 315 tests run under `pytest -n auto` in ~29s. `tests/conftest.py` adapted (paraphrase) to drop bot-loader sandboxing and bot-fixture definitions. Three telemetry/test_bot_*.py files plus `test_welcome_bot.py` stay in culture (BotManager-coupled). Bucket-C tests stay in culture indefinitely.
+> - **Remaining**: 11–12 (docs — `api-stability.md`, `cli.md`, `deployment.md`, ship in PR-B4), 14 (acceptance criteria spot-check), 16–18 (tag, publish, report-back to culture).
 >
 > Task 3 (`Copy protocol/extensions/ wholesale`) is dropped: that path doesn't exist in culture. Re-add only if/when culture creates it.
 
@@ -218,6 +218,15 @@ Tests from culture are sorted into three buckets:
 3. **Imports `culture.bots.*` or other backend-coupled fixtures** → stays in culture and is rewritten there to drive `agentirc serve` as a subprocess fixture rather than importing `IRCd` directly. Do not copy here.
 
 When in doubt, prefer moving tests *here* over leaving them in culture: this repo owns the IRCd, the client transport, and IRCd-internal tests should run in this repo's CI.
+
+**Realised in PR-B3 (9.3.0):**
+
+- 21 root server-core tests + 15 telemetry tests = 36 files (~6.5kloc) vendored verbatim with mechanical import rewrites (`culture.agentirc.X` → `agentirc.X`, `culture.protocol.message` → `agentirc._internal.protocol.message`, `culture.telemetry.X` → `agentirc._internal.telemetry.X`, `culture.agentirc.client` → `agentirc.client`).
+- `tests/conftest.py` adapted as paraphrase: dropped the `_BOTS_DIR_*` `unittest.mock.patch` calls (no-op against agentirc's no-op `_internal/bots/` stubs) and the `server_with_bot` / `server_with_bots` fixtures (`culture.bots.*` is forbidden).
+- `tests/telemetry/test_tracing.py` paraphrase: one `unittest.mock.patch` target rewritten from `"culture.telemetry.tracing.OTLPSpanExporter"` to `"agentirc._internal.telemetry.tracing.OTLPSpanExporter"`. OTEL service-name strings (`"culture.agentirc"`) and OTEL attribute keys (`"culture.s2s.*"`, `"culture.federation.peer"`, `"culture.dev/traceparent"`) preserved verbatim — they are public observability identifiers downstream consumers grep for.
+- `tests/test_events_basic.py` paraphrase: `with patch("culture.bots.bot_manager.BOTS_DIR", …)` block removed (same dead-weight rationale as the conftest patches).
+- `agentirc/server_link.py:_replay_event` parameter renamed from `_seq` (PR-B1's unused-arg compliance variant) back to `seq` to match the upstream signature culture's tests assume; signature carries a `# noqa: ARG002` to keep the linter quiet.
+- **Stayed in culture:** `test_bot_event_dispatch_span.py`, `test_bot_run_span.py`, `test_metrics_bots.py` (need real `BotManager` for the bot-event path), `test_welcome_bot.py` (inspects `bot_manager.bots`), and the 57-file bucket-C surface (cli, console, daemon, clients, credentials, mesh_config). `tests/telemetry/conftest.py` not migrated — its only consumer was the deferred bot tests above.
 
 ## Acceptance criteria
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ sha256 = "477760b85e4acf861a92aaf0ea73550c07267e3c33740a412a3075598bfb68aa"
 
 [tool.citation.packages.culture-agentirc-server-core.files."server_link.py"]
 status = "paraphrase"
-sha256 = "f2392407ebfbcdddf69316dce4a4f898384f8e2861df7391b56208240a664db0"
+sha256 = "b7c59d64c61bab8ce93595b9a406c7a6d5107ab4361a42f8ccd7ad0f5f7004e7"
 
 [tool.citation.packages.culture-agentirc-server-core.files."channel.py"]
 status = "paraphrase"
@@ -312,7 +312,7 @@ cited = "2026-05-01"
 
 [tool.citation.packages.culture-tests-conftest.files."conftest.py"]
 status = "paraphrase"
-sha256 = "89c83ce3e8c27eac03fa1f01cef21c015bb76527a71c000eef5f35b6c1f1f121"
+sha256 = "a3e893d1b483d4339237f6b459e67a962a812afed972f4e61307d64553f7f986"
 
 [tool.citation.packages.culture-tests-server-core]
 schema = 2
@@ -326,8 +326,8 @@ status = "quote"
 sha256 = "ad335460aa043e9a9e3cce3e70d3ffef4ed0f8ae98138c6b8ec26e16044b1820"
 
 [tool.citation.packages.culture-tests-server-core.files."test_connection.py"]
-status = "quote"
-sha256 = "87fd58cfe1af89f119ed96a01ffc50b8620a967cf228f03d5a297b7e4ef6682f"
+status = "paraphrase"
+sha256 = "243205febd7cfdca5b129b1ce4e1952802aa68f6999e0dc807ce15ac068dc996"
 
 [tool.citation.packages.culture-tests-server-core.files."test_discovery.py"]
 status = "quote"
@@ -358,8 +358,8 @@ status = "quote"
 sha256 = "f387befe4df163861ec4b597c0fd330745107b3e36ba5604b69d872329418f50"
 
 [tool.citation.packages.culture-tests-server-core.files."test_federation.py"]
-status = "quote"
-sha256 = "2514da859ec70874060edd60d36c7a49c703517c8b3516ee444cc35af6b9eb40"
+status = "paraphrase"
+sha256 = "3d6ebb5853571233d348c3349bb80f829025055f9036230092a83ce4e6433407"
 
 [tool.citation.packages.culture-tests-server-core.files."test_history.py"]
 status = "quote"
@@ -386,8 +386,8 @@ status = "quote"
 sha256 = "3c4e320dc459faccdf86ac67e5a33134fa5a14cc283fe1f6e79a8c09d281cd8c"
 
 [tool.citation.packages.culture-tests-server-core.files."test_rooms_federation.py"]
-status = "quote"
-sha256 = "389865fc422fd0852030f606b2f89b7e27290b064654220e1eea380ba8dc5e7e"
+status = "paraphrase"
+sha256 = "d59f7c9cc95944d1e237fff99ee795f6281dcdccfefb39f4719f43f322085148"
 
 [tool.citation.packages.culture-tests-server-core.files."test_rooms_integration.py"]
 status = "quote"
@@ -454,8 +454,8 @@ status = "quote"
 sha256 = "bfe2b1166032ec027a0ab06b3124d31a9b9deccb431d0550e14fb83f0a778f21"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_metrics_s2s.py"]
-status = "quote"
-sha256 = "de7ddb3ee302284b162066069639b914d30eef8040a1fcbf8003881b0fc5c4f6"
+status = "paraphrase"
+sha256 = "b07815fba360afda871fb2ed2996087b5778d912027751da264e188e87a7b41f"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_outbound_inject.py"]
 status = "quote"
@@ -466,16 +466,16 @@ status = "quote"
 sha256 = "5cfeffe6ccb3b18e1d78669086cc9e6e1ac473f8929eb1d1bcd15523851dd284"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_s2s_relay_span.py"]
-status = "quote"
-sha256 = "07b436dd2b5d0a1514f5282d35f10d5ff5ace1ae741346b94998c54d555b6ca4"
+status = "paraphrase"
+sha256 = "a2802230c8742b4a94e27f4854b81803119a41a5ca245d92d67001c0e2356489"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_server_init.py"]
 status = "quote"
 sha256 = "16ad131fdb48a8ff0162227f68d0b50ac4f9dc783dbd0d8061112613efff72f5"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_server_link_inject.py"]
-status = "quote"
-sha256 = "ab65be59e9369ad468e6f9bf08f8280b9a675491aa8d33604073e2df52672d9c"
+status = "paraphrase"
+sha256 = "ce2de77e1002758976e7ac50bd61cbc8a551e128b285eb01e4a1cf23ce3aa148"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_tracing.py"]
 status = "paraphrase"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "agentirc-cli"
 version = "9.3.0"
 description = "Agent-friendly IRCd: server core for AI agent meshes"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Ori Nachum" },
 ]
@@ -19,9 +19,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]
 dependencies = [
@@ -438,8 +438,8 @@ status = "quote"
 sha256 = "34cd91ef77811c5024f1534700b005605e706aaa7234bc22524aab85c272df3c"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_config.py"]
-status = "quote"
-sha256 = "25c867ee3f1b334769c4035e8ea2af59c4db405caa26406766194cb90c1255a7"
+status = "paraphrase"
+sha256 = "150f9cb11d5737f154f0f85f8e7e65135482ad86010ca2386215f9a462ad2474"
 
 [tool.citation.packages.culture-tests-telemetry.files."test_dispatch_span.py"]
 status = "quote"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentirc-cli"
-version = "9.2.0"
+version = "9.3.0"
 description = "Agent-friendly IRCd: server core for AI agent meshes"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -245,7 +245,7 @@ sha256 = "477760b85e4acf861a92aaf0ea73550c07267e3c33740a412a3075598bfb68aa"
 
 [tool.citation.packages.culture-agentirc-server-core.files."server_link.py"]
 status = "paraphrase"
-sha256 = "709a8a7d2f7836b9bf382f7fb4d5046a61f8eac06e27323d87835615314d6bbe"
+sha256 = "f2392407ebfbcdddf69316dce4a4f898384f8e2861df7391b56208240a664db0"
 
 [tool.citation.packages.culture-agentirc-server-core.files."channel.py"]
 status = "paraphrase"
@@ -302,3 +302,181 @@ sha256 = "574682bfc9f042e8c1a304db17cfb4b1e1034f384241b83aaaecfb64decb2271"
 [tool.citation.packages.culture-agentirc-server-core.files."skills/icon.py"]
 status = "paraphrase"
 sha256 = "5ef97657599a37476b96aa59968373aed8c82024027297f8300be9886dc18d4a"
+
+[tool.citation.packages.culture-tests-conftest]
+schema = 2
+source = "https://github.com/OriNachum/culture/blob/df50942/tests/conftest.py"
+version = "df50942"
+target = "tests/"
+cited = "2026-05-01"
+
+[tool.citation.packages.culture-tests-conftest.files."conftest.py"]
+status = "paraphrase"
+sha256 = "89c83ce3e8c27eac03fa1f01cef21c015bb76527a71c000eef5f35b6c1f1f121"
+
+[tool.citation.packages.culture-tests-server-core]
+schema = 2
+source = "https://github.com/OriNachum/culture/tree/df50942/tests"
+version = "df50942"
+target = "tests/"
+cited = "2026-05-01"
+
+[tool.citation.packages.culture-tests-server-core.files."test_channel.py"]
+status = "quote"
+sha256 = "ad335460aa043e9a9e3cce3e70d3ffef4ed0f8ae98138c6b8ec26e16044b1820"
+
+[tool.citation.packages.culture-tests-server-core.files."test_connection.py"]
+status = "quote"
+sha256 = "87fd58cfe1af89f119ed96a01ffc50b8620a967cf228f03d5a297b7e4ef6682f"
+
+[tool.citation.packages.culture-tests-server-core.files."test_discovery.py"]
+status = "quote"
+sha256 = "50d0dcad3f30f8b01215264147690786013e1753fae01cd682e6a415601394c8"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_basic.py"]
+status = "paraphrase"
+sha256 = "bf1e9175a6167b24c13c0f9da2eff923e7e557a3cb99606d7829a14e63596187"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_catalog.py"]
+status = "quote"
+sha256 = "4e986c18b98c6bd05232c7197c81873554225e3e7492db1b99986ac3039fec37"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_federation.py"]
+status = "quote"
+sha256 = "f79cd2caf57c264243734bc3ce9cd1cd5543afc46ee28b0a1a6c94ae50efa86a"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_history.py"]
+status = "quote"
+sha256 = "2148d1fbb951d5cf7f43d18088a92c268416ef5481837c37ca27cce3367e21db"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_lifecycle.py"]
+status = "quote"
+sha256 = "b60dc1d4eed3c6c9d689ad2a9958eee8f095d1864fbe2a3bbd3dceea52a84728"
+
+[tool.citation.packages.culture-tests-server-core.files."test_events_reserved_nick.py"]
+status = "quote"
+sha256 = "f387befe4df163861ec4b597c0fd330745107b3e36ba5604b69d872329418f50"
+
+[tool.citation.packages.culture-tests-server-core.files."test_federation.py"]
+status = "quote"
+sha256 = "2514da859ec70874060edd60d36c7a49c703517c8b3516ee444cc35af6b9eb40"
+
+[tool.citation.packages.culture-tests-server-core.files."test_history.py"]
+status = "quote"
+sha256 = "066e674c847a54ec62fccd5bbaf1c524883e47e3867f9889279d48603b83ce4d"
+
+[tool.citation.packages.culture-tests-server-core.files."test_link_reconnect.py"]
+status = "quote"
+sha256 = "0d5553353cba6d43c2af8cb8b660640cf252b3178164a3a1b623452b92f9c9ec"
+
+[tool.citation.packages.culture-tests-server-core.files."test_mentions.py"]
+status = "quote"
+sha256 = "2a0ec31bbace495fbee41813c319a3965396faaab24974fede2e8931d835b51e"
+
+[tool.citation.packages.culture-tests-server-core.files."test_messaging.py"]
+status = "quote"
+sha256 = "0e6d500f721d5ee5eba0616caeb4822ffbd7bb6f7eb9287be2aa0fea7d7293c5"
+
+[tool.citation.packages.culture-tests-server-core.files."test_modes.py"]
+status = "quote"
+sha256 = "35cd36a0171b824d638c89e021283843739eac8afc3dd846ec7e01115e6fd0e6"
+
+[tool.citation.packages.culture-tests-server-core.files."test_room_persistence.py"]
+status = "quote"
+sha256 = "3c4e320dc459faccdf86ac67e5a33134fa5a14cc283fe1f6e79a8c09d281cd8c"
+
+[tool.citation.packages.culture-tests-server-core.files."test_rooms_federation.py"]
+status = "quote"
+sha256 = "389865fc422fd0852030f606b2f89b7e27290b064654220e1eea380ba8dc5e7e"
+
+[tool.citation.packages.culture-tests-server-core.files."test_rooms_integration.py"]
+status = "quote"
+sha256 = "9dcfb16639533c44bf3633c61b19f3cd75c549cea3cdac9b5624ecf7196ab3eb"
+
+[tool.citation.packages.culture-tests-server-core.files."test_server_icon_skill.py"]
+status = "quote"
+sha256 = "c39526445af4861cab4b238ba27b00cc598cd0cf0312cea7e6d558eac62f6bd5"
+
+[tool.citation.packages.culture-tests-server-core.files."test_skills.py"]
+status = "quote"
+sha256 = "55b4d18ec526282d87055409bcc6a497a8766d2cad28b67bd5d21df9af95149f"
+
+[tool.citation.packages.culture-tests-server-core.files."test_threads.py"]
+status = "quote"
+sha256 = "0e31f65beea7521536c599b51fac36122eb9b42d50918d8c0bcb1d04d7f763bc"
+
+
+[tool.citation.packages.culture-tests-telemetry]
+schema = 2
+source = "https://github.com/OriNachum/culture/tree/df50942/tests/telemetry"
+version = "df50942"
+target = "tests/telemetry/"
+cited = "2026-05-01"
+
+[tool.citation.packages.culture-tests-telemetry.files."_fakes.py"]
+status = "quote"
+sha256 = "8358c340572006317fddadde2a07da75075f1426a3ded4cf04e4aa0b7c0f8b08"
+
+[tool.citation.packages.culture-tests-telemetry.files."_metrics_helpers.py"]
+status = "quote"
+sha256 = "1f6a01ecaa8c3577ebdd58eedb7146532688e602a2e39f3a4f323f10b6aa6c4f"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_audit_emit.py"]
+status = "quote"
+sha256 = "7b2c618443d5a5ff899ee830453537fb17256c5156c4a7242eee8017d557a2ed"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_audit_lifecycle.py"]
+status = "quote"
+sha256 = "24e17aac1d31530ed77e69f59391c30f48c69427ded4a1b28330e04464e7f872"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_audit_module.py"]
+status = "quote"
+sha256 = "e88c118abdf7f7f5241919a780417466ecf4f43180ee6dbf5253c9c05dece081"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_audit_parse_error.py"]
+status = "quote"
+sha256 = "34cd91ef77811c5024f1534700b005605e706aaa7234bc22524aab85c272df3c"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_config.py"]
+status = "quote"
+sha256 = "25c867ee3f1b334769c4035e8ea2af59c4db405caa26406766194cb90c1255a7"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_dispatch_span.py"]
+status = "quote"
+sha256 = "a5116e92d1d88da18f2cd5d026b69c0efbcdf3845c3da4c5f3177dfa46ade7fb"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_emit_event_span.py"]
+status = "quote"
+sha256 = "5fb0cf247669717f1add5392d18d3a5639d35d3350982b521a40e3ad031bc7ab"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_metrics_init.py"]
+status = "quote"
+sha256 = "bfe2b1166032ec027a0ab06b3124d31a9b9deccb431d0550e14fb83f0a778f21"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_metrics_s2s.py"]
+status = "quote"
+sha256 = "de7ddb3ee302284b162066069639b914d30eef8040a1fcbf8003881b0fc5c4f6"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_outbound_inject.py"]
+status = "quote"
+sha256 = "1b2a5132dc1b02cb19ca9aa3edc951c2d0431ff9a26e649175eef72faafb7168"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_parse_error.py"]
+status = "quote"
+sha256 = "5cfeffe6ccb3b18e1d78669086cc9e6e1ac473f8929eb1d1bcd15523851dd284"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_s2s_relay_span.py"]
+status = "quote"
+sha256 = "07b436dd2b5d0a1514f5282d35f10d5ff5ace1ae741346b94998c54d555b6ca4"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_server_init.py"]
+status = "quote"
+sha256 = "16ad131fdb48a8ff0162227f68d0b50ac4f9dc783dbd0d8061112613efff72f5"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_server_link_inject.py"]
+status = "quote"
+sha256 = "ab65be59e9369ad468e6f9bf08f8280b9a675491aa8d33604073e2df52672d9c"
+
+[tool.citation.packages.culture-tests-telemetry.files."test_tracing.py"]
+status = "paraphrase"
+sha256 = "1847662286c1d15848ae3624f61c88f78f1f5d16ab30af3e77981c94e9e5c86d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,7 +312,7 @@ cited = "2026-05-01"
 
 [tool.citation.packages.culture-tests-conftest.files."conftest.py"]
 status = "paraphrase"
-sha256 = "a3e893d1b483d4339237f6b459e67a962a812afed972f4e61307d64553f7f986"
+sha256 = "3ee6fd43e2833f28a75363503519d63a16fe6f89843471707bf684e544cac360"
 
 [tool.citation.packages.culture-tests-server-core]
 schema = 2
@@ -359,15 +359,15 @@ sha256 = "f387befe4df163861ec4b597c0fd330745107b3e36ba5604b69d872329418f50"
 
 [tool.citation.packages.culture-tests-server-core.files."test_federation.py"]
 status = "paraphrase"
-sha256 = "3d6ebb5853571233d348c3349bb80f829025055f9036230092a83ce4e6433407"
+sha256 = "1a1812cdbbf3adf026dc52c791ceb45b076b4eea7f0aa5f9f048a631628aee1f"
 
 [tool.citation.packages.culture-tests-server-core.files."test_history.py"]
 status = "quote"
 sha256 = "066e674c847a54ec62fccd5bbaf1c524883e47e3867f9889279d48603b83ce4d"
 
 [tool.citation.packages.culture-tests-server-core.files."test_link_reconnect.py"]
-status = "quote"
-sha256 = "0d5553353cba6d43c2af8cb8b660640cf252b3178164a3a1b623452b92f9c9ec"
+status = "paraphrase"
+sha256 = "876330d0fa8db1dcabcc352c362e0b59c7b6a02bb689e61a8e1e464af3ecf058"
 
 [tool.citation.packages.culture-tests-server-core.files."test_mentions.py"]
 status = "quote"

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -65,6 +65,10 @@ async def boot_linked_pair(
     server_b = IRCd(config_b)
     await server_a.start()
     await server_b.start()
+    # `_server` is set by `start()` — assert for type-checker / SonarCloud
+    # S2259, since the IRCd type carries `_server: asyncio.AbstractServer | None`.
+    assert server_a._server is not None
+    assert server_b._server is not None
     server_a.config.port = server_a._server.sockets[0].getsockname()[1]
     server_b.config.port = server_b._server.sockets[0].getsockname()[1]
     return server_a, server_b

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,92 @@
+"""Shared test helpers, agentirc-native (NOT vendored from culture).
+
+Extracted to address SonarCloud's >3% duplication threshold. The
+boot-linked-pair pattern repeats verbatim across the cited
+``test_federation.py`` (5 sites), ``test_link_reconnect.py`` (3
+sites), and the ``linked_servers`` conftest fixture; CPD flags it as
+~22 lines × 9 = ~200 lines of duplicated test scaffold.
+
+Why these tests can't share the existing ``linked_servers`` pytest
+fixture: each one needs to drive the boot/link/teardown lifecycle
+itself — duplicate-link rejection, slow-link teardown, mid-test
+peer kill, backfill replay — and the function-scoped fixture starts
+both servers + completes the handshake before the test body runs.
+
+Re-snapshotting from a future culture commit means re-running the
+same extraction: replace each ~22-line inline boot block with a
+single ``boot_linked_pair(tmp_path)`` call. Mechanical sed pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+
+from tests.conftest import TEST_LINK_PASSWORD
+
+
+async def boot_linked_pair(
+    tmp_path,
+    *,
+    link_password: str = TEST_LINK_PASSWORD,
+    with_audit: bool = False,
+    webhook_port: int | None = None,
+) -> tuple[IRCd, IRCd]:
+    """Boot two IRCd instances pre-wired with link configs.
+
+    Returns ``(server_a, server_b)`` after both ``start()`` calls
+    have returned with OS-assigned ports populated. Does NOT drive
+    the S2S handshake — caller decides whether to call
+    :func:`link_pair` or invoke ``connect_to_peer`` manually.
+
+    ``with_audit=True`` plumbs ``TelemetryConfig(audit_dir=...)``
+    onto each side, isolating audit JSONL writes to ``tmp_path``.
+    ``webhook_port=0`` suppresses the webhook listener — the
+    ``linked_servers`` fixture sets this; the inline sites do not.
+    """
+    kwargs_a: dict = {"links": [
+        LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)
+    ]}
+    kwargs_b: dict = {"links": [
+        LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)
+    ]}
+    if with_audit:
+        kwargs_a["telemetry"] = TelemetryConfig(audit_dir=str(tmp_path / "audit_alpha"))
+        kwargs_b["telemetry"] = TelemetryConfig(audit_dir=str(tmp_path / "audit_beta"))
+    if webhook_port is not None:
+        kwargs_a["webhook_port"] = webhook_port
+        kwargs_b["webhook_port"] = webhook_port
+
+    config_a = ServerConfig(name="alpha", host="127.0.0.1", port=0, **kwargs_a)
+    config_b = ServerConfig(name="beta", host="127.0.0.1", port=0, **kwargs_b)
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    return server_a, server_b
+
+
+async def link_pair(
+    server_a: IRCd,
+    server_b: IRCd,
+    *,
+    link_password: str = TEST_LINK_PASSWORD,
+) -> None:
+    """Drive the S2S handshake on a booted linked-pair.
+
+    Updates each side's ``LinkConfig`` with the actual OS-assigned
+    port (the ``links=[…port=0]`` placeholder gets resolved here),
+    calls ``connect_to_peer`` from A → B, and polls up to ~2.5s for
+    both sides to see the link before returning.
+    """
+    server_a.config.links[0].port = server_b.config.port
+    server_b.config.links[0].port = server_a.config.port
+    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+    for _ in range(50):
+        if "beta" in server_a.links and "alpha" in server_b.links:
+            break
+        await asyncio.sleep(0.05)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,45 +159,12 @@ async def make_client(server):
 @pytest_asyncio.fixture
 async def linked_servers(tmp_path):
     """Two IRCd instances linked via S2S federation."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair, link_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        webhook_port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_alpha")),
+    server_a, server_b = await boot_linked_pair(
+        tmp_path, with_audit=True, webhook_port=0
     )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        webhook_port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_beta")),
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-
-    await server_a.start()
-    await server_b.start()
-
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
-
-    # Update link configs with actual ports
-    config_a.links[0].port = server_b.config.port
-    config_b.links[0].port = server_a.config.port
-
-    # Server A connects to Server B
-    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
-    # Wait for handshake to complete
-    for _ in range(50):
-        if "beta" in server_a.links and "alpha" in server_b.links:
-            break
-        await asyncio.sleep(0.05)
+    await link_pair(server_a, server_b)
 
     yield server_a, server_b
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,328 @@
+"""Shared test fixtures for the agentirc suite.
+
+Vendored from ``culture@df50942`` (`tests/conftest.py`) and adapted
+for agentirc per the cite-don't-copy convention. Two adaptations
+versus the upstream copy:
+
+- The upstream conftest sandboxes culture's bot loader by patching
+  ``culture.bots.{bot_manager,config,bot}.BOTS_DIR`` to an empty
+  temp dir on every IRCd-spawning fixture. agentirc's
+  ``agentirc/_internal/bots/`` modules are no-op stubs (synthesized
+  in PR-B1) with no ``BOTS_DIR`` constant and a ``load_bots()`` that
+  returns immediately, so the patches are dead weight here.
+- The upstream ``server_with_bot`` and ``server_with_bots`` fixtures
+  import ``culture.bots.{bot_manager, config}`` directly and have no
+  agentirc analogue (real BotManager is forbidden by the dependency
+  boundary). They are dropped; the three telemetry tests that
+  depended on them (``test_bot_event_dispatch_span``,
+  ``test_bot_run_span``, ``test_metrics_bots``) stay in culture.
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metrics
+from agentirc._internal.telemetry.tracing import reset_for_tests as _reset_telemetry
+
+# Test-only link password — not a real credential (S2068)
+TEST_LINK_PASSWORD = "testlink123"  # noqa: S105
+
+# Default total wait for recv_until / recv. Callers needing a different
+# bound should wrap their own `async with asyncio.timeout(...)` around the
+# call rather than passing a parameter (per python:S7483).
+RECV_TIMEOUT_SECONDS = 2.0
+
+
+class IRCTestClient:
+    """A minimal IRC test client over raw TCP."""
+
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        self.reader = reader
+        self.writer = writer
+        self._buffer = ""
+
+    async def send(self, text: str) -> None:
+        self.writer.write(f"{text}\r\n".encode())
+        await self.writer.drain()
+
+    async def recv(self, timeout: float = 2.0) -> str:
+        while "\r\n" not in self._buffer:
+            data = await asyncio.wait_for(self.reader.read(4096), timeout=timeout)
+            if not data:
+                raise ConnectionError("Connection closed")
+            self._buffer += data.decode()
+        line, self._buffer = self._buffer.split("\r\n", 1)
+        return line
+
+    async def recv_all(self, timeout: float = 0.5) -> list[str]:
+        lines = []
+        try:
+            while True:
+                lines.append(await self.recv(timeout=timeout))
+        except (asyncio.TimeoutError, ConnectionError):
+            pass
+        return lines
+
+    async def recv_until(self, marker: str) -> str:
+        """Read lines until one contains marker.
+
+        Bounded by `RECV_TIMEOUT_SECONDS` (module constant). For a
+        different bound, wrap the call in `async with asyncio.timeout(...)`.
+        """
+        collected = []
+        try:
+            async with asyncio.timeout(RECV_TIMEOUT_SECONDS):
+                while True:
+                    line = await self.recv()
+                    collected.append(line)
+                    if marker in line:
+                        return "\r\n".join(collected)
+        except (asyncio.TimeoutError, TimeoutError, ConnectionError):
+            pass
+        return "\r\n".join(collected)
+
+    async def count_until_idle(self, marker: str, seconds: float = 1.0) -> int:
+        """Read lines until timeout; return count of lines containing marker."""
+        count = 0
+        try:
+            while True:
+                line = await self.recv(timeout=seconds)
+                if marker in line:
+                    count += 1
+        except (asyncio.TimeoutError, ConnectionError):
+            pass
+        return count
+
+    async def close(self) -> None:
+        self.writer.close()
+        try:
+            await self.writer.wait_closed()
+        except ConnectionError:
+            pass
+
+
+@pytest_asyncio.fixture
+async def server(tmp_path):
+    config = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit")),
+    )
+    ircd = IRCd(config)
+    await ircd.start()
+    # Get actual port from OS-assigned random port
+    ircd.config.port = ircd._server.sockets[0].getsockname()[1]
+    yield ircd
+    await ircd.stop()
+
+
+@pytest_asyncio.fixture
+async def make_client(server):
+    clients = []
+
+    async def _make(nick: str | None = None, user: str | None = None) -> IRCTestClient:
+        reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)
+        client = IRCTestClient(reader, writer)
+        if nick:
+            await client.send(f"NICK {nick}")
+        if user:
+            await client.send(f"USER {user} 0 * :{user}")
+        if nick and user:
+            # Drain welcome messages
+            await client.recv_all(timeout=0.5)
+        clients.append(client)
+        return client
+
+    yield _make
+
+    for c in clients:
+        try:
+            await c.close()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def linked_servers(tmp_path):
+    """Two IRCd instances linked via S2S federation."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_alpha")),
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_beta")),
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    # Update link configs with actual ports
+    config_a.links[0].port = server_b.config.port
+    config_b.links[0].port = server_a.config.port
+
+    # Server A connects to Server B
+    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+    # Wait for handshake to complete
+    for _ in range(50):
+        if "beta" in server_a.links and "alpha" in server_b.links:
+            break
+        await asyncio.sleep(0.05)
+
+    yield server_a, server_b
+
+    await server_a.stop()
+    await server_b.stop()
+
+
+@pytest_asyncio.fixture
+async def make_client_a(linked_servers):
+    """Create test clients connected to server A."""
+    server_a, _ = linked_servers
+    clients = []
+
+    async def _make(nick: str | None = None, user: str | None = None) -> IRCTestClient:
+        reader, writer = await asyncio.open_connection("127.0.0.1", server_a.config.port)
+        client = IRCTestClient(reader, writer)
+        if nick:
+            await client.send(f"NICK {nick}")
+        if user:
+            await client.send(f"USER {user} 0 * :{user}")
+        if nick and user:
+            await client.recv_all(timeout=0.5)
+        clients.append(client)
+        return client
+
+    yield _make
+
+    for c in clients:
+        try:
+            await c.close()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def make_client_b(linked_servers):
+    """Create test clients connected to server B."""
+    _, server_b = linked_servers
+    clients = []
+
+    async def _make(nick: str | None = None, user: str | None = None) -> IRCTestClient:
+        reader, writer = await asyncio.open_connection("127.0.0.1", server_b.config.port)
+        client = IRCTestClient(reader, writer)
+        if nick:
+            await client.send(f"NICK {nick}")
+        if user:
+            await client.send(f"USER {user} 0 * :{user}")
+        if nick and user:
+            await client.recv_all(timeout=0.5)
+        clients.append(client)
+        return client
+
+    yield _make
+
+    for c in clients:
+        try:
+            await c.close()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def server_welcome_disabled(tmp_path):
+    """Server instance with the welcome system bot disabled via config."""
+    config = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        system_bots={"welcome": {"enabled": False}},
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit")),
+    )
+    ircd = IRCd(config)
+    await ircd.start()
+    ircd.config.port = ircd._server.sockets[0].getsockname()[1]
+    yield ircd
+    await ircd.stop()
+
+
+@pytest_asyncio.fixture
+async def tracing_exporter():
+    """In-memory span exporter for telemetry integration tests.
+
+    Installs a dedicated SDK TracerProvider with a SimpleSpanProcessor so
+    every finished span lands in the returned exporter synchronously. Cleans
+    up after the test so it doesn't leak into parallel workers.
+    """
+    _reset_telemetry()
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        exporter.clear()
+        _reset_telemetry()
+
+
+@pytest_asyncio.fixture
+async def metrics_reader():
+    """In-memory metric reader for telemetry integration tests.
+
+    Installs a dedicated SDK MeterProvider with an InMemoryMetricReader so
+    tests can `reader.get_metrics_data()` to walk recorded data points.
+    Cleans up after the test so it doesn't leak into parallel workers.
+    """
+    _reset_metrics()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    try:
+        yield reader
+    finally:
+        _reset_metrics()
+
+
+@pytest.fixture
+def audit_dir(tmp_path):
+    """Yields a Path for tests to use as `telemetry.audit_dir`.
+
+    Tests build a ServerConfig with `telemetry=TelemetryConfig(audit_dir=str(tmp_path))`
+    and inspect file contents via `Path(audit_dir).glob("*.jsonl*")`.
+    """
+    return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metri
 from agentirc._internal.telemetry.tracing import reset_for_tests as _reset_telemetry
 
 # Test-only link password — not a real credential (S2068)
-TEST_LINK_PASSWORD = "testlink123"  # noqa: S105
+TEST_LINK_PASSWORD = "testlink123"  # noqa: S105  # NOSONAR S2068 — test fixture, not a real credential
 
 # Default total wait for recv_until / recv. Callers needing a different
 # bound should wrap their own `async with asyncio.timeout(...)` around the
@@ -57,7 +57,7 @@ class IRCTestClient:
         self.writer.write(f"{text}\r\n".encode())
         await self.writer.drain()
 
-    async def recv(self, timeout: float = 2.0) -> str:
+    async def recv(self, timeout: float = 2.0) -> str:  # NOSONAR S7483 — public test-helper signature; see RECV_TIMEOUT_SECONDS note above
         while "\r\n" not in self._buffer:
             data = await asyncio.wait_for(self.reader.read(4096), timeout=timeout)
             if not data:
@@ -66,7 +66,7 @@ class IRCTestClient:
         line, self._buffer = self._buffer.split("\r\n", 1)
         return line
 
-    async def recv_all(self, timeout: float = 0.5) -> list[str]:
+    async def recv_all(self, timeout: float = 0.5) -> list[str]:  # NOSONAR S7483
         lines = []
         try:
             while True:

--- a/tests/telemetry/_fakes.py
+++ b/tests/telemetry/_fakes.py
@@ -1,0 +1,26 @@
+"""Shared test doubles for client-side telemetry unit tests.
+
+Integration coverage (real TCP to a real IRCd) lives in
+`tests/telemetry/test_privmsg_span.py`. The fake writer below is for
+targeted byte-level assertions on `Client.send` / `Client.send_raw`
+injection behavior, where a full server round-trip would add cost
+without extra signal.
+"""
+
+from __future__ import annotations
+
+
+class FakeWriter:
+    """Minimal asyncio StreamWriter stand-in for client-side unit tests."""
+
+    def __init__(self) -> None:
+        self.buf: list[bytes] = []
+
+    def get_extra_info(self, key: str, default=None):
+        return ("testaddr", 12345) if key == "peername" else default
+
+    def write(self, data: bytes) -> None:
+        self.buf.append(data)
+
+    async def drain(self) -> None:
+        """No-op: tests never block on socket flush."""

--- a/tests/telemetry/_metrics_helpers.py
+++ b/tests/telemetry/_metrics_helpers.py
@@ -1,0 +1,75 @@
+"""Helpers for asserting on InMemoryMetricReader output in metrics tests.
+
+reader.get_metrics_data() returns a MetricsData object whose nested
+structure is resource_metrics → scope_metrics → metrics → data points.
+These helpers walk it for the common assertions we need."""
+
+from __future__ import annotations
+
+
+def _walk_data_points(reader, name: str):
+    """Yield every data point across all resources/scopes for a metric `name`."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    yield from metric.data.data_points
+
+
+def _attrs_match(point_attrs: dict, expected: dict | None) -> bool:
+    if not expected:
+        return True
+    return all(point_attrs.get(k) == v for k, v in expected.items())
+
+
+def get_counter_value(reader, name: str, attrs: dict | None = None) -> float:
+    """Sum of counter values for points matching `attrs`. 0.0 if absent.
+
+    attrs=None or attrs={} matches all points (sums across all label combinations).
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
+    total = 0.0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.value
+    return total
+
+
+def get_up_down_value(reader, name: str, attrs: dict | None = None) -> float:
+    """Latest UpDownCounter value for points matching `attrs`. 0.0 if absent.
+
+    attrs=None or attrs={} matches all points.
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            return point.value
+    return 0.0
+
+
+def get_histogram_count(reader, name: str, attrs: dict | None = None) -> int:
+    """Count of recorded values for histogram points matching `attrs`.
+
+    attrs=None or attrs={} matches all points (sums counts across all label combinations).
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
+    total = 0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.count
+    return total
+
+
+def get_histogram_sum(reader, name: str, attrs: dict | None = None) -> float:
+    """Sum of recorded values for histogram points matching `attrs`. 0.0 if absent."""
+    total = 0.0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.sum
+    return total

--- a/tests/telemetry/test_audit_emit.py
+++ b/tests/telemetry/test_audit_emit.py
@@ -1,0 +1,145 @@
+"""Tests for IRCd.emit_event audit submit wiring.
+
+Verifies a single emit_event produces a JSONL record with the right
+shape (event_type, origin/peer, trace_id/span_id, actor, target,
+payload, tags). Federation, parse_error, and queue overflow live in
+their own test files (Tasks 6/7)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc.skill import Event, EventType
+
+
+def _build_server(audit_dir):
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    return IRCd(cfg)
+
+
+def _read_records(audit_dir, server_name="testserv"):
+    files = sorted(audit_dir.glob(f"{server_name}-*.jsonl*"))
+    out = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_emit_event_writes_audit_record(audit_dir, tracing_exporter):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel="#test",
+                nick="testserv-alice",
+                data={"text": "hello world"},
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    # Records: SERVER_WAKE (from start), our MESSAGE, SERVER_SLEEP (from stop).
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert len(msg_records) == 1, f"expected 1 message record, got {records}"
+    rec = msg_records[0]
+    assert rec["server"] == "testserv"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "channel", "name": "#test"}
+    assert rec["actor"]["nick"] == "testserv-alice"
+    assert rec["actor"]["kind"] == "human"
+    assert rec["payload"]["text"] == "hello world"
+    assert rec["payload"]["nick"] == "testserv-alice"
+    assert rec["payload"]["channel"] == "#test"
+    # ts shape
+    assert "T" in rec["ts"] and rec["ts"].endswith("Z")
+    # trace_id/span_id may be empty if no span context wraps the
+    # caller, but emit_event opens its own span so they MUST be set.
+    assert len(rec["trace_id"]) == 32
+    assert len(rec["span_id"]) == 16
+    assert rec["tags"]["culture.dev/traceparent"].startswith("00-")
+    assert rec["trace_id"] in rec["tags"]["culture.dev/traceparent"]
+
+
+@pytest.mark.asyncio
+async def test_emit_event_strips_underscore_keys_from_payload(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel="#test",
+                nick="testserv-bob",
+                data={
+                    "text": "hi",
+                    "_origin": "alpha",
+                    "_internal_state": "x",
+                },
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert msg_records, f"expected message record, got {records}"
+    rec = msg_records[0]
+    assert "_origin" not in rec["payload"]
+    assert "_internal_state" not in rec["payload"]
+    # _origin makes the event federated.
+    assert rec["origin"] == "federated"
+    assert rec["peer"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_emit_event_dm_target(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel=None,
+                nick="testserv-alice",
+                data={"text": "secret", "target": "testserv-bob"},
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert msg_records
+    rec = msg_records[0]
+    assert rec["target"] == {"kind": "nick", "name": "testserv-bob"}
+
+
+@pytest.mark.asyncio
+async def test_server_wake_and_sleep_appear_in_audit(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    await server.stop()
+    records = _read_records(audit_dir)
+    types = [r["event_type"] for r in records]
+    assert "server.wake" in types
+    assert "server.sleep" in types

--- a/tests/telemetry/test_audit_lifecycle.py
+++ b/tests/telemetry/test_audit_lifecycle.py
@@ -1,0 +1,69 @@
+"""Smoke test for IRCd-managed AuditSink lifecycle.
+
+This test exists to verify the wiring: IRCd.start() actually awaits
+sink.start(), and IRCd.stop() actually awaits sink.shutdown().
+The audit sink itself is exercised in test_audit_module.py; integration
+tests covering submit() during the lifecycle land in Task 5/Task 7."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.telemetry.audit import reset_for_tests as _reset_audit
+from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    _reset_audit()
+    yield
+    _reset_audit()
+    _reset_metrics()
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_starts_and_shuts_down_with_ircd(audit_dir):
+    """IRCd.start() opens the audit dir and writer task; stop() drains it."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    assert server.audit is not None
+    assert server.audit._writer_task is None  # not started yet
+
+    await server.start()
+    try:
+        assert server.audit._writer_task is not None
+        assert audit_dir.exists()
+    finally:
+        await server.stop()
+
+    # After stop, the writer task should be cancelled.
+    assert server.audit._writer_task is None
+
+
+@pytest.mark.asyncio
+async def test_audit_disabled_does_not_create_directory(tmp_path):
+    """audit_enabled=False should not create the audit dir."""
+    audit_dir = tmp_path / "should-not-exist"
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(
+            audit_dir=str(audit_dir),
+            audit_enabled=False,
+        ),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        assert not audit_dir.exists(), f"audit_enabled=False but dir was created at {audit_dir}"
+    finally:
+        await server.stop()

--- a/tests/telemetry/test_audit_module.py
+++ b/tests/telemetry/test_audit_module.py
@@ -1,0 +1,306 @@
+"""Module-level tests for AuditSink + init_audit + helpers.
+
+Exercises the sink directly without spinning up an IRCd; integration
+tests live in tests/telemetry/test_audit_*.py (Task 7)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.skill import Event, EventType
+from agentirc._internal.telemetry import AuditSink, init_audit
+from agentirc._internal.telemetry.audit import build_audit_record as _build_audit_record
+from agentirc._internal.telemetry.audit import reset_for_tests as _reset_audit
+from agentirc._internal.telemetry.audit import utc_iso_timestamp as _utc_iso_timestamp
+from agentirc._internal.telemetry.metrics import init_metrics
+from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    _reset_audit()
+    yield
+    _reset_audit()
+    _reset_metrics()
+
+
+def _build_config(tmp_path, **overrides):
+    tcfg = TelemetryConfig(audit_dir=str(tmp_path), **overrides)
+    return ServerConfig(name="testserv", telemetry=tcfg)
+
+
+# --- _utc_iso_timestamp ---------------------------------------------------
+
+
+def test_iso_timestamp_format():
+    ts = _utc_iso_timestamp(0.0)
+    assert ts == "1970-01-01T00:00:00.000000Z"
+
+
+def test_iso_timestamp_microseconds_padded():
+    ts = _utc_iso_timestamp(0.000005)
+    assert ts.endswith(".000005Z")
+
+
+# --- _build_audit_record --------------------------------------------------
+
+
+def test_record_local_message_event():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="testserv-alice",
+        data={"text": "hi"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag=None,
+        trace_id="",
+        span_id="",
+    )
+    assert record["server"] == "testserv"
+    assert record["event_type"] == "message"
+    assert record["origin"] == "local"
+    assert record["peer"] == ""
+    assert record["target"] == {"kind": "channel", "name": "#general"}
+    assert record["actor"]["nick"] == "testserv-alice"
+    assert record["actor"]["kind"] == "human"
+    assert record["payload"]["text"] == "hi"
+    assert record["payload"]["nick"] == "testserv-alice"
+    assert record["payload"]["channel"] == "#general"
+    assert record["tags"] == {}
+
+
+def test_record_federated_strips_underscore_keys():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="alpha-alice",
+        data={"text": "hi", "_origin": "alpha", "_internal": "x"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag="alpha",
+        trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id="00f067aa0ba902b7",
+    )
+    assert record["origin"] == "federated"
+    assert record["peer"] == "alpha"
+    assert record["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert "_origin" not in record["payload"]
+    assert "_internal" not in record["payload"]
+    assert record["payload"]["text"] == "hi"
+
+
+def test_record_dm_target_kind_nick():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel=None,
+        nick="testserv-alice",
+        data={"text": "hi", "target": "testserv-bob"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv", event=event, origin_tag=None, trace_id="", span_id=""
+    )
+    assert record["target"] == {"kind": "nick", "name": "testserv-bob"}
+
+
+def test_record_unknown_event_type_string():
+    """Federated events sometimes carry event.type as a plain string."""
+    event = Event(
+        type="custom.future_event",  # type: ignore[arg-type]
+        channel=None,
+        nick="alpha-alice",
+        data={"_origin": "alpha"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv", event=event, origin_tag="alpha", trace_id="", span_id=""
+    )
+    assert record["event_type"] == "custom.future_event"
+
+
+def test_record_extra_tags_traceparent():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="testserv-alice",
+        data={"text": "hi"},
+        timestamp=0.0,
+    )
+    tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag=None,
+        trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id="00f067aa0ba902b7",
+        extra_tags={"culture.dev/traceparent": tp},
+    )
+    assert record["tags"]["culture.dev/traceparent"] == tp
+
+
+# --- init_audit -----------------------------------------------------------
+
+
+def test_init_audit_returns_sink_when_disabled(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    assert isinstance(sink, AuditSink)
+    assert sink.enabled is False
+    # No-op submit must not raise.
+    sink.submit({"event_type": "test"})
+
+
+def test_init_audit_idempotent_same_config(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink1 = init_audit(cfg, metrics)
+    sink2 = init_audit(cfg, metrics)
+    assert sink1 is sink2
+
+
+def test_init_audit_independent_of_telemetry_enabled(tmp_path):
+    """audit_enabled=True should fire even with telemetry.enabled=False."""
+    cfg = _build_config(tmp_path, enabled=False, audit_enabled=True)
+    metrics = init_metrics(cfg)  # no-op proxy meter
+    sink = init_audit(cfg, metrics)
+    assert sink.enabled is True
+
+
+def test_init_audit_expands_tilde(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = _build_config(tmp_path)
+    cfg.telemetry.audit_dir = "~/audit-test"
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    assert sink.audit_dir == tmp_path / "audit-test"
+
+
+# --- AuditSink lifecycle + write ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sink_start_creates_directory(tmp_path):
+    audit_dir = tmp_path / "audit"
+    cfg = _build_config(audit_dir)
+    cfg.telemetry.audit_dir = str(audit_dir)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        assert audit_dir.exists()
+        assert audit_dir.is_dir()
+    finally:
+        await sink.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sink_writes_record_to_jsonl(tmp_path):
+    cfg = _build_config(tmp_path)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        sink.submit({"event_type": "test", "n": 1})
+        sink.submit({"event_type": "test", "n": 2})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+
+    files = list(tmp_path.glob("testserv-*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["n"] == 1
+    assert json.loads(lines[1])["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sink_disabled_writes_nothing(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        sink.submit({"event_type": "test"})
+        await asyncio.sleep(0.05)
+    finally:
+        await sink.shutdown()
+    assert list(tmp_path.glob("*.jsonl")) == []
+
+
+@pytest.mark.asyncio
+async def test_sink_size_rotation(tmp_path):
+    cfg = _build_config(tmp_path, audit_max_file_bytes=200)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        for i in range(20):
+            sink.submit({"event_type": "test", "i": i, "padding": "x" * 50})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+
+    files = sorted(tmp_path.glob("testserv-*.jsonl*"))
+    # With 200-byte cap and ~80-byte records, expect at least 2 files.
+    assert len(files) >= 2, f"expected >=2 rotated files, got {[f.name for f in files]}"
+
+
+@pytest.mark.asyncio
+async def test_sink_overflow_drops_records(tmp_path):
+    """Queue depth 2; flood 10. Some must be dropped."""
+    cfg = _build_config(tmp_path, audit_queue_depth=2)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    # Don't await between submits — pile records up before the writer
+    # task can pull them.
+    try:
+        for i in range(10):
+            sink.submit({"event_type": "test", "i": i})
+        # Let writer finish what it can.
+        await asyncio.sleep(0.1)
+    finally:
+        await sink.shutdown()
+    files = list(tmp_path.glob("*.jsonl"))
+    written = files[0].read_text().splitlines() if files else []
+    # Some records should have been dropped — strict equality on count is
+    # racy because the writer may have drained 1 before we filled, so just
+    # assert "less than 10".
+    assert len(written) < 10, f"expected drops, all 10 written: {written}"
+
+
+@pytest.mark.asyncio
+async def test_sink_writes_oversized_record_into_fresh_file(tmp_path):
+    """A single record larger than audit_max_file_bytes is still written —
+    the cap is a soft ceiling for accumulated bytes, not a hard reject."""
+    cfg = _build_config(tmp_path, audit_max_file_bytes=100)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        big = {"event_type": "test", "padding": "x" * 500}  # ~530 bytes
+        sink.submit(big)
+        sink.submit({"event_type": "test", "n": 2})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+    files = sorted(tmp_path.glob("testserv-*.jsonl*"))
+    # Oversized record forces rotation; second record forces another.
+    assert len(files) >= 2
+    # The oversized record must be in one of the files.
+    all_lines = "\n".join(f.read_text() for f in files)
+    assert "x" * 500 in all_lines

--- a/tests/telemetry/test_audit_parse_error.py
+++ b/tests/telemetry/test_audit_parse_error.py
@@ -1,0 +1,177 @@
+"""PARSE_ERROR audit records from Client._process_buffer.
+
+Verifies a malformed inbound line produces a PARSE_ERROR JSONL record
+with the right shape: line_preview (truncated to 64 chars), error type,
+remote_addr from peer info, trace_id/span_id from the active
+irc.client.process_buffer span.
+
+NOTE: Message.parse is fully tolerant and never raises for any syntactically
+constructable input. Tests therefore use mock.patch to force a ValueError
+from Message.parse — this is the only reliable way to exercise the
+except-branch in _process_buffer. The unit tests below validate the
+record shape directly via _submit_parse_error_audit, and via a patched
+_process_buffer round-trip against a real IRCd.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agentirc.client import Client
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.protocol.message import Message
+from tests.telemetry._fakes import FakeWriter
+
+# ---------------------------------------------------------------------------
+# Unit-level: _submit_parse_error_audit builds the right record shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_error_audit_record_shape(audit_dir, tracing_exporter):
+    """_submit_parse_error_audit enqueues a well-formed PARSE_ERROR record."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        client = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+        client.nick = "testserv-alice"
+
+        # Call _submit_parse_error_audit directly (no real parse failure needed).
+        client._submit_parse_error_audit("GARBAGE_LINE_THAT_FAILED", ValueError("bad"))
+
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    files = sorted(audit_dir.glob("testserv-*.jsonl*"))
+    records = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+
+    parse_errors = [r for r in records if r["event_type"] == "PARSE_ERROR"]
+    assert len(parse_errors) == 1, f"expected 1 PARSE_ERROR record, got {records}"
+
+    rec = parse_errors[0]
+    assert rec["server"] == "testserv"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "", "name": ""}
+    assert rec["actor"]["nick"] == "testserv-alice"
+    assert rec["actor"]["kind"] == "human"
+    # FakeWriter returns ("testaddr", 12345) for peername.
+    assert rec["actor"]["remote_addr"] == "testaddr:12345"
+    assert rec["payload"]["line_preview"] == "GARBAGE_LINE_THAT_FAILED"
+    assert rec["payload"]["error"] == "ValueError"
+    assert "T" in rec["ts"] and rec["ts"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_error_line_preview_truncated_to_64(audit_dir, tracing_exporter):
+    """line_preview is truncated to 64 characters."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        client = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+        client.nick = "testserv-bob"
+
+        long_line = "X" * 200
+        client._submit_parse_error_audit(long_line, RuntimeError("too long"))
+
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    files = sorted(audit_dir.glob("testserv-*.jsonl*"))
+    records = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+
+    parse_errors = [r for r in records if r["event_type"] == "PARSE_ERROR"]
+    assert parse_errors, "expected a PARSE_ERROR record"
+    rec = parse_errors[0]
+    assert len(rec["payload"]["line_preview"]) == 64
+    assert rec["payload"]["error"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _process_buffer calls _submit_parse_error_audit on exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_buffer_submits_audit_on_parse_exception(audit_dir, tracing_exporter, server):
+    """When Message.parse raises, _process_buffer calls _submit_parse_error_audit."""
+    client_obj = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+    client_obj.nick = "testserv-carol"
+
+    submitted: list[dict] = []
+    original_submit = server.audit.submit
+
+    def _capturing_submit(record):
+        submitted.append(record)
+        original_submit(record)
+
+    server.audit.submit = _capturing_submit  # type: ignore[method-assign]
+
+    def _boom(_line):
+        raise ValueError("deliberate parse failure")
+
+    with patch.object(Message, "parse", side_effect=_boom):
+        await client_obj._process_buffer("BAD LINE\n")
+
+    assert len(submitted) == 1
+    rec = submitted[0]
+    assert rec["event_type"] == "PARSE_ERROR"
+    assert rec["server"] == server.config.name
+    assert rec["payload"]["line_preview"].startswith("BAD LINE")
+    assert rec["payload"]["error"] == "ValueError"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "", "name": ""}
+    assert rec["actor"]["kind"] == "human"
+    # trace_id and span_id should be set — process_buffer opens a span.
+    assert len(rec["trace_id"]) == 32
+    assert len(rec["span_id"]) == 16
+    assert rec["tags"]["culture.dev/traceparent"].startswith("00-")
+
+
+@pytest.mark.asyncio
+async def test_process_buffer_audit_disabled_does_not_raise(tracing_exporter):
+    """When audit is disabled, _process_buffer parse errors don't crash."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_enabled=False),
+    )
+    server = IRCd(cfg)
+    client_obj = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+    client_obj.nick = "testserv-dave"
+
+    def _boom(_line):
+        raise ValueError("deliberate parse failure")
+
+    with patch.object(Message, "parse", side_effect=_boom):
+        # Should not raise even though audit is disabled (submit is a no-op).
+        await client_obj._process_buffer("BAD LINE\n")

--- a/tests/telemetry/test_config.py
+++ b/tests/telemetry/test_config.py
@@ -5,7 +5,7 @@ def test_default_server_config_has_telemetry_disabled():
     cfg = ServerConfig()
     assert cfg.telemetry.enabled is False
     assert cfg.telemetry.service_name == "culture.agentirc"
-    assert cfg.telemetry.otlp_endpoint == "http://localhost:4317"
+    assert cfg.telemetry.otlp_endpoint == "http://localhost:4317"  # NOSONAR S5332 — localhost OTLP test fixture, never reaches wire
     assert cfg.telemetry.otlp_timeout_ms == 5000
     assert cfg.telemetry.traces_enabled is True
     assert cfg.telemetry.traces_sampler == "parentbased_always_on"
@@ -15,12 +15,12 @@ def test_telemetry_config_accepts_overrides():
     t = TelemetryConfig(
         enabled=True,
         service_name="culture.agentirc.alpha",
-        otlp_endpoint="http://collector:4317",
+        otlp_endpoint="http://collector:4317",  # NOSONAR S5332 — test fixture string, never reaches wire
         otlp_timeout_ms=2000,
         traces_sampler="parentbased_traceidratio:0.1",
     )
     assert t.enabled is True
     assert t.service_name == "culture.agentirc.alpha"
-    assert t.otlp_endpoint == "http://collector:4317"
+    assert t.otlp_endpoint == "http://collector:4317"  # NOSONAR S5332
     assert t.otlp_timeout_ms == 2000
     assert t.traces_sampler == "parentbased_traceidratio:0.1"

--- a/tests/telemetry/test_config.py
+++ b/tests/telemetry/test_config.py
@@ -1,0 +1,26 @@
+from agentirc.config import ServerConfig, TelemetryConfig
+
+
+def test_default_server_config_has_telemetry_disabled():
+    cfg = ServerConfig()
+    assert cfg.telemetry.enabled is False
+    assert cfg.telemetry.service_name == "culture.agentirc"
+    assert cfg.telemetry.otlp_endpoint == "http://localhost:4317"
+    assert cfg.telemetry.otlp_timeout_ms == 5000
+    assert cfg.telemetry.traces_enabled is True
+    assert cfg.telemetry.traces_sampler == "parentbased_always_on"
+
+
+def test_telemetry_config_accepts_overrides():
+    t = TelemetryConfig(
+        enabled=True,
+        service_name="culture.agentirc.alpha",
+        otlp_endpoint="http://collector:4317",
+        otlp_timeout_ms=2000,
+        traces_sampler="parentbased_traceidratio:0.1",
+    )
+    assert t.enabled is True
+    assert t.service_name == "culture.agentirc.alpha"
+    assert t.otlp_endpoint == "http://collector:4317"
+    assert t.otlp_timeout_ms == 2000
+    assert t.traces_sampler == "parentbased_traceidratio:0.1"

--- a/tests/telemetry/test_dispatch_span.py
+++ b/tests/telemetry/test_dispatch_span.py
@@ -1,0 +1,45 @@
+import pytest
+
+from agentirc.client import Client
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.protocol.message import Message
+from agentirc._internal.telemetry.context import TRACEPARENT_TAG
+from tests.telemetry._fakes import FakeWriter
+
+
+@pytest.mark.asyncio
+async def test_dispatch_creates_command_span(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.nick = "spark-alice"
+    await client._dispatch(Message(command="PING", params=["token1"]))
+    names = [s.name for s in tracing_exporter.get_finished_spans()]
+    assert "irc.command.PING" in names
+
+
+@pytest.mark.asyncio
+async def test_dispatch_extracts_traceparent(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.nick = "spark-alice"
+    tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    await client._dispatch(Message(tags={TRACEPARENT_TAG: tp}, command="PING", params=["token1"]))
+    span = next(s for s in tracing_exporter.get_finished_spans() if s.name == "irc.command.PING")
+    # Trace ID encoded from traceparent (middle hex group).
+    assert format(span.context.trace_id, "032x") == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert span.attributes["culture.trace.origin"] == "remote"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_malformed_traceparent_drops_to_root(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.nick = "spark-alice"
+    await client._dispatch(Message(tags={TRACEPARENT_TAG: "garbage"}, command="PING", params=["t"]))
+    span = next(s for s in tracing_exporter.get_finished_spans() if s.name == "irc.command.PING")
+    assert span.attributes["culture.trace.origin"] == "remote"
+    assert span.attributes["culture.trace.dropped_reason"] == "malformed"

--- a/tests/telemetry/test_emit_event_span.py
+++ b/tests/telemetry/test_emit_event_span.py
@@ -1,0 +1,42 @@
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_emit_event_creates_span(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    # IRCd uses the module-level tracer from telemetry.tracing; the fixture
+    # installed a real SDK provider so spans land in the exporter regardless
+    # of telemetry.enabled.
+    ircd = IRCd(cfg)
+    await ircd.emit_event(
+        Event(type=EventType.MESSAGE, channel="#c", nick="spark-alice", data={"body": "hi"})
+    )
+    spans = tracing_exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    assert "irc.event.emit" in names
+    event_span = next(s for s in spans if s.name == "irc.event.emit")
+    assert event_span.attributes["event.type"] == "message"
+    assert event_span.attributes["event.channel"] == "#c"
+    assert event_span.attributes["event.origin"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_emit_event_federated_origin(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    await ircd.emit_event(
+        Event(
+            type=EventType.MESSAGE,
+            channel="#c",
+            nick="thor-bob",
+            data={"body": "hi", "_origin": "thor"},
+        )
+    )
+    spans = tracing_exporter.get_finished_spans()
+    event_span = next(s for s in spans if s.name == "irc.event.emit")
+    assert event_span.attributes["event.origin"] == "federated"
+    assert event_span.attributes["culture.federation.peer"] == "thor"

--- a/tests/telemetry/test_metrics_init.py
+++ b/tests/telemetry/test_metrics_init.py
@@ -1,0 +1,58 @@
+"""Tests for init_metrics + reset_for_tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc._internal.telemetry import MetricsRegistry, init_metrics
+from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    yield
+    _reset_metrics()
+
+
+def test_init_metrics_returns_registry_when_disabled():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg = init_metrics(cfg)
+    assert isinstance(reg, MetricsRegistry)
+    # No-op meter still satisfies the interface — call sites can record unconditionally.
+    reg.events_emitted.add(1, {"event.type": "MESSAGE", "origin": "local"})
+
+
+def test_init_metrics_returns_registry_when_metrics_disabled_only():
+    cfg = ServerConfig(
+        name="testserv",
+        telemetry=TelemetryConfig(enabled=True, metrics_enabled=False),
+    )
+    reg = init_metrics(cfg)
+    assert isinstance(reg, MetricsRegistry)
+
+
+def test_init_metrics_idempotent_same_config():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg1 = init_metrics(cfg)
+    reg2 = init_metrics(cfg)
+    assert reg1 is reg2
+
+
+def test_init_metrics_reinit_on_config_mutation():
+    tcfg = TelemetryConfig(enabled=False)
+    cfg = ServerConfig(name="testserv", telemetry=tcfg)
+    reg1 = init_metrics(cfg)
+    # Mutate the config in place — snapshot diff should trigger reinit.
+    tcfg.metrics_export_interval_ms = 5000
+    reg2 = init_metrics(cfg)
+    assert reg1 is not reg2
+
+
+def test_reset_for_tests_clears_state():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg1 = init_metrics(cfg)
+    _reset_metrics()
+    reg2 = init_metrics(cfg)
+    assert reg1 is not reg2

--- a/tests/telemetry/test_metrics_s2s.py
+++ b/tests/telemetry/test_metrics_s2s.py
@@ -1,0 +1,160 @@
+"""Tests for federation metrics: s2s.messages, relay_latency, links_active, link_events."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentirc.config import LinkConfig, ServerConfig
+from agentirc.ircd import IRCd
+from tests.telemetry._metrics_helpers import (
+    get_counter_value,
+    get_histogram_count,
+    get_up_down_value,
+)
+
+
+@pytest.mark.asyncio
+async def test_s2s_messages_counter_inbound(metrics_reader, linked_servers):
+    """Inbound S2S verbs (handshake + burst) increment s2s_messages."""
+    # By the time linked_servers yields, PASS, SERVER, and burst messages
+    # have all flowed inbound on each side.
+    n_pass = get_counter_value(
+        metrics_reader,
+        "culture.s2s.messages",
+        attrs={"verb": "PASS", "direction": "inbound"},
+    )
+    n_server = get_counter_value(
+        metrics_reader,
+        "culture.s2s.messages",
+        attrs={"verb": "SERVER", "direction": "inbound"},
+    )
+    assert n_pass >= 1, f"expected ≥1 PASS, got {n_pass}"
+    assert n_server >= 1, f"expected ≥1 SERVER, got {n_server}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_links_active_increments_after_handshake(metrics_reader, linked_servers):
+    """links_active = +1 on each side once handshake completes."""
+    n_outbound = get_up_down_value(
+        metrics_reader,
+        "culture.s2s.links_active",
+        attrs={"peer": "beta", "direction": "outbound"},
+    )
+    n_inbound = get_up_down_value(
+        metrics_reader,
+        "culture.s2s.links_active",
+        attrs={"peer": "alpha", "direction": "inbound"},
+    )
+    assert n_outbound == 1, f"expected 1 outbound link, got {n_outbound}"
+    assert n_inbound == 1, f"expected 1 inbound link, got {n_inbound}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_connect(metrics_reader, linked_servers):
+    """connect event fires once per side on handshake completion."""
+    n_outbound = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "beta", "event": "connect"},
+    )
+    n_inbound = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "alpha", "event": "connect"},
+    )
+    assert n_outbound >= 1, f"expected ≥1 outbound connect, got {n_outbound}"
+    assert n_inbound >= 1, f"expected ≥1 inbound connect, got {n_inbound}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_relay_latency_histogram(metrics_reader, linked_servers, make_client_a):
+    """relay_event records to s2s_relay_latency when an event relays."""
+    _ = linked_servers  # required for fixture setup
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #relay-test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+    # JOIN events relay to peer; relay_event fires.
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.s2s.relay_latency",
+        attrs={"peer": "beta"},
+    )
+    assert n >= 1, f"expected ≥1 relay latency sample, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_disconnect(metrics_reader, linked_servers):
+    """disconnect event fires when the link tears down."""
+    server_a, _ = linked_servers
+    link = server_a.links["beta"]
+    await link.send_raw("SQUIT alpha :test shutdown")
+    await asyncio.sleep(0.5)
+    # Allow finally block to run on both sides.
+    n = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "beta", "event": "disconnect"},
+    )
+    assert n >= 1, f"expected ≥1 disconnect, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_auth_fail():
+    """Bad password fires auth_fail."""
+    # We need a manually-built tracing setup since this test doesn't use
+    # linked_servers. Use a fresh metrics_reader fixture pattern inline.
+    from opentelemetry import metrics as otel_metrics
+    from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    from agentirc._internal.telemetry.metrics import reset_for_tests as _reset_metrics
+
+    _reset_metrics()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    try:
+        config_a = ServerConfig(name="alpha", host="127.0.0.1", port=0)
+        config_b = ServerConfig(
+            name="beta",
+            host="127.0.0.1",
+            port=0,
+            links=[
+                LinkConfig(
+                    name="alpha",
+                    host="127.0.0.1",
+                    port=0,
+                    password="correct",  # nosec B106 - test fixture, intentional bad-password assertion
+                )
+            ],
+        )
+
+        server_a = IRCd(config_a)
+        server_b = IRCd(config_b)
+        await server_a.start()
+        await server_b.start()
+
+        server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+        server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+        try:
+            await server_a.connect_to_peer("127.0.0.1", server_b.config.port, "wrong")
+            await asyncio.sleep(0.5)
+            n = get_counter_value(
+                reader,
+                "culture.s2s.link_events",
+                attrs={"peer": "alpha", "event": "auth_fail"},
+            )
+            assert n >= 1, f"expected ≥1 auth_fail on bad password, got {n}"
+        finally:
+            await server_a.stop()
+            await server_b.stop()
+    finally:
+        _reset_metrics()

--- a/tests/telemetry/test_metrics_s2s.py
+++ b/tests/telemetry/test_metrics_s2s.py
@@ -131,7 +131,7 @@ async def test_s2s_link_events_auth_fail():
                     name="alpha",
                     host="127.0.0.1",
                     port=0,
-                    password="correct",  # nosec B106 - test fixture, intentional bad-password assertion
+                    password="correct",  # nosec B106  # NOSONAR S2068 — test fixture, intentional bad-password assertion
                 )
             ],
         )

--- a/tests/telemetry/test_outbound_inject.py
+++ b/tests/telemetry/test_outbound_inject.py
@@ -1,0 +1,70 @@
+import pytest
+
+from agentirc.client import Client
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.protocol.message import Message
+from agentirc._internal.telemetry.context import TRACEPARENT_TAG
+from tests.telemetry._fakes import FakeWriter
+
+
+@pytest.mark.asyncio
+async def test_send_injects_traceparent_when_span_active(tracing_exporter):
+    from opentelemetry import trace
+
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.caps = {"message-tags"}
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("outer"):
+        await client.send(Message(command="PRIVMSG", params=["#c", "hi"]))
+    wire = client.writer.buf[0].decode()
+    assert TRACEPARENT_TAG in wire
+
+
+@pytest.mark.asyncio
+async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
+    from opentelemetry import trace
+
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.caps = {"message-tags"}
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("outer"):
+        await client.send_raw("PRIVMSG #c :hi")
+    wire = client.writer.buf[0].decode()
+    assert TRACEPARENT_TAG in wire
+
+
+@pytest.mark.asyncio
+async def test_send_no_injection_when_no_active_span(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.caps = {"message-tags"}
+    # No active span → no injection
+    await client.send(Message(command="PRIVMSG", params=["#c", "hi"]))
+    wire = client.writer.buf[0].decode()
+    assert TRACEPARENT_TAG not in wire
+
+
+@pytest.mark.asyncio
+async def test_send_no_injection_when_caps_missing(tracing_exporter):
+    from opentelemetry import trace
+
+    # Client has not negotiated message-tags — traceparent MUST NOT be
+    # injected, or older clients would see an unexpected @-tag block.
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    assert "message-tags" not in client.caps
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("outer"):
+        await client.send(Message(command="PRIVMSG", params=["#c", "hi"]))
+        await client.send_raw("NOTICE #c :raw")
+    send_wire = client.writer.buf[0].decode()
+    raw_wire = client.writer.buf[1].decode()
+    assert TRACEPARENT_TAG not in send_wire
+    assert TRACEPARENT_TAG not in raw_wire

--- a/tests/telemetry/test_parse_error.py
+++ b/tests/telemetry/test_parse_error.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+import pytest
+
+from agentirc.client import Client
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+from agentirc._internal.protocol.message import Message
+from tests.telemetry._fakes import FakeWriter
+
+
+@pytest.mark.asyncio
+async def test_parse_error_surfaces_as_span_event(tracing_exporter):
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    client = Client(reader=None, writer=FakeWriter(), server=ircd)  # type: ignore[arg-type]
+    client.nick = "spark-alice"
+
+    def _boom(_line):
+        raise ValueError("bad line")
+
+    # _process_buffer opens its own span "irc.client.process_buffer"; parse
+    # errors from Message.parse are attached as events on that span.
+    with patch.object(Message, "parse", side_effect=_boom):
+        await client._process_buffer("GARBAGE\n")
+
+    spans = tracing_exporter.get_finished_spans()
+    buf_span = next(s for s in spans if s.name == "irc.client.process_buffer")
+    event_names = [e.name for e in buf_span.events]
+    assert "irc.parse_error" in event_names
+    parse_evt = next(e for e in buf_span.events if e.name == "irc.parse_error")
+    assert parse_evt.attributes["error"] == "ValueError"
+    assert parse_evt.attributes["line_preview"].startswith("GARBAGE")

--- a/tests/telemetry/test_s2s_relay_span.py
+++ b/tests/telemetry/test_s2s_relay_span.py
@@ -16,7 +16,7 @@ from agentirc.skill import Event, EventType
 from agentirc._internal.telemetry.context import TRACEPARENT_TAG
 
 
-async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:
+async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:  # NOSONAR S7483
     deadline = asyncio.get_event_loop().time() + timeout
     while asyncio.get_event_loop().time() < deadline:
         if any(s.name == name for s in exporter.get_finished_spans()):
@@ -100,7 +100,7 @@ async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
     line = smsg_lines[0]
     # Extract the traceparent value from the @-tag block.
     tag_block = line.split(" ", 1)[0][1:]
-    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)
+    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)  # NOSONAR S7494
     tp_value = tags[TRACEPARENT_TAG]
     # W3C: 00-<trace-id>-<parent-id>-<flags>
     parts = tp_value.split("-")

--- a/tests/telemetry/test_s2s_relay_span.py
+++ b/tests/telemetry/test_s2s_relay_span.py
@@ -1,0 +1,114 @@
+"""Tests for the irc.s2s.relay span on ServerLink.relay_event.
+
+Verifies the per-hop re-sign rule from culture/protocol/extensions/tracing.md:
+the wire-injected traceparent's parent-id matches the relay span's id (NOT
+the inbound trace's parent-id), even when an inbound trace context is active.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from opentelemetry import trace as otel_trace
+
+from agentirc.skill import Event, EventType
+from agentirc._internal.telemetry.context import TRACEPARENT_TAG
+
+
+async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(s.name == name for s in exporter.get_finished_spans()):
+            return
+        await asyncio.sleep(0.02)
+
+
+def _spans_with_name(exporter, name):
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_relay_span_recorded_with_event_type_and_peer(tracing_exporter, linked_servers):
+    server_a, _ = linked_servers
+    tracing_exporter.clear()
+
+    # Trigger a relay by calling relay_event directly (skip _dispatch path).
+    link_to_b = server_a.links["beta"]
+    event = Event(
+        type=EventType.MESSAGE,
+        channel=None,
+        nick="alpha-bob",
+        data={"target": "alpha-charlie", "text": "hi"},
+    )
+    await link_to_b.relay_event(event)
+
+    await _wait_for_span(tracing_exporter, "irc.s2s.relay")
+    spans = _spans_with_name(tracing_exporter, "irc.s2s.relay")
+    assert spans, "no irc.s2s.relay span recorded"
+    span = spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("event.type") == "message"
+    assert attrs.get("s2s.peer") == "beta"
+
+
+@pytest.mark.asyncio
+async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
+    """Outbound traceparent on relayed wire bytes points to the relay span,
+    NOT to whatever inbound trace was active. This is the per-hop re-sign rule.
+    """
+    server_a, _ = linked_servers
+    tracing_exporter.clear()
+
+    # Record raw bytes server_b sees on the link from alpha. We swap the
+    # writer's `write` method on the alpha->beta link with a recording one,
+    # then call relay_event from inside an outer span. The outer span
+    # simulates an "inbound" trace context that should NOT leak into the wire.
+    link_to_b = server_a.links["beta"]
+    captured: list[bytes] = []
+    real_write = link_to_b.writer.write
+
+    def recording_write(data):
+        captured.append(data)
+        return real_write(data)
+
+    link_to_b.writer.write = recording_write
+
+    tracer = otel_trace.get_tracer("test")
+    outer_span_id_hex = None
+    try:
+        with tracer.start_as_current_span("simulated_inbound") as outer:
+            outer_span_id_hex = format(outer.get_span_context().span_id, "016x")
+            event = Event(
+                type=EventType.MESSAGE,
+                channel=None,
+                nick="alpha-bob",
+                data={"target": "alpha-charlie", "text": "ping"},
+            )
+            await link_to_b.relay_event(event)
+    finally:
+        link_to_b.writer.write = real_write
+
+    # Find the wire bytes that carry the SMSG line.
+    relayed = [b.decode("utf-8", errors="replace") for b in captured]
+    smsg_lines = [
+        line
+        for line in "".join(relayed).split("\r\n")
+        if " SMSG " in line and TRACEPARENT_TAG in line
+    ]
+    assert smsg_lines, f"expected an SMSG line carrying traceparent, got: {relayed!r}"
+    line = smsg_lines[0]
+    # Extract the traceparent value from the @-tag block.
+    tag_block = line.split(" ", 1)[0][1:]
+    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)
+    tp_value = tags[TRACEPARENT_TAG]
+    # W3C: 00-<trace-id>-<parent-id>-<flags>
+    parts = tp_value.split("-")
+    assert len(parts) == 4, f"malformed traceparent: {tp_value!r}"
+    parent_id_hex = parts[2]
+    # The wire parent-id MUST NOT equal the outer span's id — that would mean
+    # we copied the inbound traceparent verbatim instead of re-signing.
+    assert parent_id_hex != outer_span_id_hex, (
+        f"wire parent-id {parent_id_hex!r} matches outer span "
+        f"{outer_span_id_hex!r} — re-sign rule violated"
+    )

--- a/tests/telemetry/test_server_init.py
+++ b/tests/telemetry/test_server_init.py
@@ -1,0 +1,29 @@
+import pytest
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc.ircd import IRCd
+
+
+def test_ircd_init_sets_tracer_attribute():
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    ircd = IRCd(cfg)
+    assert ircd.tracer is not None
+    # No-op tracer can still produce spans; is_recording will be False
+    with ircd.tracer.start_as_current_span("check") as span:
+        assert span.is_recording() is False
+
+
+@pytest.mark.asyncio
+async def test_ircd_init_does_not_disturb_installed_provider(tracing_exporter):
+    # tracing_exporter fixture already installed an SDK provider; IRCd.__init__
+    # with enabled=False must NOT tear that down (its no-op path must not call
+    # trace.set_tracer_provider).
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    IRCd(cfg)
+    # Emit a span via the exporter's provider — must land in the exporter.
+    from opentelemetry import trace
+
+    tracer = trace.get_tracer("smoke")
+    with tracer.start_as_current_span("smoke") as span:
+        assert span.is_recording()
+    assert len(tracing_exporter.get_finished_spans()) == 1

--- a/tests/telemetry/test_server_link_inject.py
+++ b/tests/telemetry/test_server_link_inject.py
@@ -1,0 +1,124 @@
+"""Wire-level injection tests for ServerLink.send_raw — the single choke point
+that re-signs every outbound federation line with the current span's W3C
+traceparent (per `culture/protocol/extensions/tracing.md`)."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace as otel_trace
+
+from agentirc.server_link import ServerLink, _prepend_trace_tags
+from agentirc._internal.telemetry import current_traceparent
+from agentirc._internal.telemetry.context import TRACEPARENT_TAG
+
+VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+# --- _prepend_trace_tags helper unit tests --------------------------------
+
+
+def test_prepend_to_untagged_line():
+    line = ":alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert out == f"@{TRACEPARENT_TAG}={VALID_TP} {line}"
+
+
+def test_prepend_merges_into_existing_tag_block():
+    line = "@vendor=foo :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert out == f"@vendor=foo;{TRACEPARENT_TAG}={VALID_TP} :alpha SMSG #room alpha-bob :hi"
+
+
+def test_prepend_replaces_existing_traceparent_in_tag_block():
+    stale = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00"
+    line = f"@{TRACEPARENT_TAG}={stale};vendor=x :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    expected = f"@{TRACEPARENT_TAG}={VALID_TP};vendor=x :alpha SMSG #room alpha-bob :hi"
+    assert out == expected
+
+
+def test_prepend_empty_line_no_op():
+    assert _prepend_trace_tags("", VALID_TP) == ""
+
+
+def test_prepend_into_tag_only_line_with_no_space():
+    # Edge case: line is entirely a tag block with no body. Defensive only —
+    # never happens on the wire, but the helper must not raise.
+    line = "@vendor=foo"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+    assert "vendor=foo" in out
+
+
+def test_prepend_preserves_tag_value_with_equals_signs():
+    # Tag values can legally contain '=' inside the value portion.
+    line = "@vendor=k=v :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert "vendor=k=v" in out
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+
+
+def test_prepend_into_empty_tag_block_no_leading_semicolon():
+    # @<empty> rest — must not produce '@;TP=...' (leading empty tag).
+    line = "@ :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert ";;" not in out
+    assert not out.startswith("@;")
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+
+
+# --- ServerLink.send_raw injection (uses ServerLink with a fake writer) ----
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.buf: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.buf.append(data)
+
+    async def drain(self) -> None:
+        """No-op: tests don't exercise asyncio writer back-pressure."""
+
+
+@pytest.mark.asyncio
+async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("smoke"):
+        await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+
+    assert len(writer.buf) == 1
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    prefix, sep, body = line.partition(" ")
+    assert sep == " "
+    assert prefix.startswith("@")
+    tags = dict(t.split("=", 1) for t in prefix[1:].split(";") if "=" in t)
+    assert TRACEPARENT_TAG in tags
+    # Tag value must be 55-char W3C format
+    assert len(tags[TRACEPARENT_TAG]) == 55
+    assert body == ":alpha SMSG #room alpha-bob :hi"
+
+
+@pytest.mark.asyncio
+async def test_send_raw_no_injection_when_no_span(tracing_exporter):
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    # No span started.
+    await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    assert TRACEPARENT_TAG not in line
+
+
+@pytest.mark.asyncio
+async def test_send_raw_traceparent_matches_active_span(tracing_exporter):
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("smoke"):
+        expected_tp = current_traceparent()
+        await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    assert f"{TRACEPARENT_TAG}={expected_tp}" in line

--- a/tests/telemetry/test_server_link_inject.py
+++ b/tests/telemetry/test_server_link_inject.py
@@ -94,7 +94,7 @@ async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
     prefix, sep, body = line.partition(" ")
     assert sep == " "
     assert prefix.startswith("@")
-    tags = dict(t.split("=", 1) for t in prefix[1:].split(";") if "=" in t)
+    tags = dict(t.split("=", 1) for t in prefix[1:].split(";") if "=" in t)  # NOSONAR S7494
     assert TRACEPARENT_TAG in tags
     # Tag value must be 55-char W3C format
     assert len(tags[TRACEPARENT_TAG]) == 55

--- a/tests/telemetry/test_tracing.py
+++ b/tests/telemetry/test_tracing.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+from agentirc.config import ServerConfig, TelemetryConfig
+from agentirc._internal.telemetry import init_telemetry
+from agentirc._internal.telemetry.tracing import reset_for_tests
+
+
+def setup_function():
+    reset_for_tests()
+
+
+def teardown_function():
+    reset_for_tests()
+
+
+def test_init_disabled_returns_noop_tracer():
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    tracer = init_telemetry(cfg)
+    # NoOpTracer spans are context managers that do nothing.
+    with tracer.start_as_current_span("test") as span:
+        # NoOp spans have no recording behavior; is_recording() is False.
+        assert span.is_recording() is False
+
+
+def test_init_enabled_creates_sdk_tracer():
+    cfg = ServerConfig(
+        name="spark",
+        telemetry=TelemetryConfig(enabled=True, otlp_endpoint="http://localhost:4317"),
+    )
+    with patch(
+        "agentirc._internal.telemetry.tracing.OTLPSpanExporter"
+    ) as mock_exporter:  # avoid real gRPC connection in tests
+        init_telemetry(cfg)
+    mock_exporter.assert_called_once()
+    call_kwargs = mock_exporter.call_args.kwargs
+    assert call_kwargs["endpoint"] == "http://localhost:4317"
+    # Tracer should resolve to the SDK provider we installed.
+    provider = trace.get_tracer_provider()
+    assert isinstance(provider, SdkTracerProvider)
+
+
+def test_init_is_idempotent():
+    cfg = ServerConfig(name="spark", telemetry=TelemetryConfig(enabled=False))
+    t1 = init_telemetry(cfg)
+    t2 = init_telemetry(cfg)
+    assert t1 is t2

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,131 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_join_channel(server, make_client):
+    """Client can join a channel and receives NAMES list."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "JOIN" in joined
+    assert "#general" in joined
+    assert "353" in joined  # RPL_NAMREPLY
+    assert "366" in joined  # RPL_ENDOFNAMES
+    assert "testserv-ori" in joined
+
+
+@pytest.mark.asyncio
+async def test_join_notifies_others(server, make_client):
+    """Existing channel members see the JOIN."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+
+    # client1 should see client2's join
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "JOIN" in joined
+    assert "testserv-claude" in joined
+
+
+@pytest.mark.asyncio
+async def test_part_channel(server, make_client):
+    """Client can leave a channel."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("PART #general :bye")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "PART" in joined
+    assert "#general" in joined
+
+
+@pytest.mark.asyncio
+async def test_part_not_on_channel(server, make_client):
+    """PART on a channel you're not in returns error."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("PART #general")
+    response = await client.recv()
+    assert "442" in response  # ERR_NOTONCHANNEL
+
+
+@pytest.mark.asyncio
+async def test_topic_set_and_get(server, make_client):
+    """Client can set and query channel topic."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("TOPIC #general :Building culture")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "TOPIC" in joined
+    assert "Building culture" in joined
+
+    await client.send("TOPIC #general")
+    response = await client.recv()
+    assert "332" in response  # RPL_TOPIC
+    assert "Building culture" in response
+
+
+@pytest.mark.asyncio
+async def test_topic_no_topic_set(server, make_client):
+    """Querying topic on channel without topic returns RPL_NOTOPIC."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("TOPIC #general")
+    response = await client.recv()
+    assert "331" in response  # RPL_NOTOPIC
+
+
+@pytest.mark.asyncio
+async def test_names_list(server, make_client):
+    """NAMES returns all members of a channel."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("NAMES #general")
+    lines = await client1.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "testserv-ori" in names_line
+    assert "testserv-claude" in names_line
+
+
+@pytest.mark.asyncio
+async def test_join_channel_with_topic(server, make_client):
+    """Joining a channel with a topic shows the topic."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client1.send("TOPIC #general :Welcome to culture")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    lines = await client2.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "332" in joined
+    assert "Welcome to culture" in joined
+
+
+@pytest.mark.asyncio
+async def test_channel_name_must_start_with_hash(server, make_client):
+    """JOIN without # prefix is silently ignored."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN general")
+    lines = await client.recv_all(timeout=0.5)
+    # Should get nothing back (no join, no error)
+    join_lines = [l for l in lines if "JOIN" in l]
+    assert len(join_lines) == 0

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,135 @@
+# tests/test_connection.py
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_server_accepts_connection(server):
+    """Server accepts a TCP connection."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)
+    writer.close()
+    await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_server_responds_to_ping(server, make_client):
+    """Server responds to PING with PONG."""
+    client = await make_client()
+    await client.send("PING :hello")
+    response = await client.recv()
+    assert "PONG" in response
+    assert "hello" in response
+
+
+@pytest.mark.asyncio
+async def test_registration_welcome(server, make_client):
+    """Client receives 001-004 after NICK + USER."""
+    client = await make_client()
+    await client.send("NICK testserv-ori")
+    await client.send("USER ori 0 * :Ori Nachum")
+    lines = await client.recv_all(timeout=1.0)
+    codes = [line.split()[1] for line in lines]
+    assert "001" in codes
+    assert "002" in codes
+    assert "003" in codes
+    assert "004" in codes
+
+
+@pytest.mark.asyncio
+async def test_nick_must_have_server_prefix(server, make_client):
+    """Nick without server name prefix is rejected."""
+    client = await make_client()
+    await client.send("NICK claude")
+    response = await client.recv()
+    assert "432" in response  # ERR_ERRONEUSNICKNAME
+
+
+@pytest.mark.asyncio
+async def test_nick_empty_agent_rejected(server, make_client):
+    """Nick with server prefix but no agent name is rejected."""
+    client = await make_client()
+    await client.send("NICK testserv-")
+    response = await client.recv()
+    assert "432" in response  # ERR_ERRONEUSNICKNAME
+
+
+@pytest.mark.asyncio
+async def test_nick_with_correct_prefix(server, make_client):
+    """Nick with correct server prefix is accepted."""
+    client = await make_client()
+    await client.send("NICK testserv-claude")
+    await client.send("USER claude 0 * :Claude")
+    lines = await client.recv_all(timeout=1.0)
+    codes = [line.split()[1] for line in lines]
+    assert "001" in codes
+
+
+@pytest.mark.asyncio
+async def test_duplicate_nick_rejected(server, make_client):
+    """Second client with same nick is rejected."""
+    await make_client(nick="testserv-claude", user="claude")
+    client2 = await make_client()
+    await client2.send("NICK testserv-claude")
+    response = await client2.recv()
+    assert "433" in response  # ERR_NICKNAMEINUSE
+
+
+@pytest.mark.asyncio
+async def test_nick_no_param(server, make_client):
+    """NICK without parameter returns ERR_NONICKNAMEGIVEN."""
+    client = await make_client()
+    await client.send("NICK")
+    response = await client.recv()
+    assert "431" in response
+
+
+@pytest.mark.asyncio
+async def test_user_without_nick(server, make_client):
+    """USER without prior NICK does not trigger welcome."""
+    client = await make_client()
+    await client.send("USER ori 0 * :Ori")
+    lines = await client.recv_all(timeout=0.5)
+    codes = [line.split()[1] for line in lines if len(line.split()) > 1]
+    assert "001" not in codes
+
+
+@pytest.mark.asyncio
+async def test_double_registration_rejected(server, make_client):
+    """USER sent twice returns ERR_ALREADYREGISTRED."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("USER ori 0 * :Ori again")
+    response = await client.recv()
+    assert "462" in response
+
+
+@pytest.mark.asyncio
+async def test_quit_notifies_channel_members(server, make_client):
+    """QUIT sends quit message to channel members."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client2.send("QUIT :going offline")
+    lines = await client1.recv_all(timeout=1.0)
+    quit_lines = [l for l in lines if "QUIT" in l]
+    assert len(quit_lines) > 0
+    assert "going offline" in quit_lines[0]
+    assert "testserv-claude" in quit_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_quit_removes_from_server(server, make_client):
+    """After QUIT, nick is available again."""
+    client1 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("QUIT :bye")
+    await client1.recv_all(timeout=0.5)
+    # Small delay for server cleanup
+    await asyncio.sleep(0.2)
+
+    # Should be able to reuse the nick
+    client2 = await make_client(nick="testserv-claude", user="claude2")
+    assert client2 is not None  # registered successfully

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_server_accepts_connection(server):
     """Server accepts a TCP connection."""
-    reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)  # NOSONAR S1481
     writer.close()
     await writer.wait_closed()
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,169 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_who_channel_lists_members(server, make_client):
+    """WHO #channel lists all members."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("WHO #general")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "352" in joined  # RPL_WHOREPLY
+    assert "testserv-ori" in joined
+    assert "testserv-claude" in joined
+    assert "315" in joined  # RPL_ENDOFWHO
+
+
+@pytest.mark.asyncio
+async def test_who_shows_op_prefix(server, make_client):
+    """WHO shows H@ for operators and H+ for voiced."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    # Grant voice to claude
+    await client1.send("MODE #general +v testserv-claude")
+    await client1.recv_all(timeout=0.5)
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("WHO #general")
+    lines = await client1.recv_all(timeout=1.0)
+    who_lines = [l for l in lines if "352" in l]
+    ori_line = [l for l in who_lines if "testserv-ori H" in l][0]
+    claude_line = [l for l in who_lines if "testserv-claude H" in l][0]
+    assert "H@" in ori_line
+    assert "H+" in claude_line
+
+
+@pytest.mark.asyncio
+async def test_who_by_nick(server, make_client):
+    """WHO <nick> returns info for that nick."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("WHO testserv-claude")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "352" in joined
+    assert "testserv-claude" in joined
+    assert "#general" in joined
+    assert "315" in joined
+
+
+@pytest.mark.asyncio
+async def test_who_nonexistent_channel(server, make_client):
+    """WHO on nonexistent channel returns only ENDOFWHO."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("WHO #doesnotexist")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "315" in joined
+    assert "352" not in joined
+
+
+@pytest.mark.asyncio
+async def test_who_no_params(server, make_client):
+    """WHO with no params returns ENDOFWHO."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("WHO")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "315" in joined
+
+
+@pytest.mark.asyncio
+async def test_whois_returns_user_info(server, make_client):
+    """WHOIS returns user info, server, and channels."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("WHOIS testserv-claude")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "311" in joined  # RPL_WHOISUSER
+    assert "312" in joined  # RPL_WHOISSERVER
+    assert "319" in joined  # RPL_WHOISCHANNELS
+    assert "318" in joined  # RPL_ENDOFWHOIS
+    assert "testserv-claude" in joined
+    assert "#general" in joined
+
+
+@pytest.mark.asyncio
+async def test_whois_channels_show_mode_prefixes(server, make_client):
+    """WHOIS channels show @/+ prefixes for ops/voiced."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    # ori is op
+    await client1.send("WHOIS testserv-ori")
+    lines = await client1.recv_all(timeout=1.0)
+    chan_line = [l for l in lines if "319" in l][0]
+    assert "@#general" in chan_line
+
+
+@pytest.mark.asyncio
+async def test_whois_nonexistent_nick(server, make_client):
+    """WHOIS on unknown nick returns 401 + ENDOFWHOIS."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("WHOIS testserv-nobody")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "401" in joined  # ERR_NOSUCHNICK
+    assert "318" in joined  # RPL_ENDOFWHOIS
+
+
+@pytest.mark.asyncio
+async def test_whois_no_params(server, make_client):
+    """WHOIS with no params returns ERR_NONICKNAMEGIVEN."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("WHOIS")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "431" in joined  # ERR_NONICKNAMEGIVEN
+
+
+@pytest.mark.asyncio
+async def test_who_nick_not_in_any_channel(server, make_client):
+    """WHO <nick> for a user not in any channel shows * for channel."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("WHO testserv-claude")
+    lines = await client1.recv_all(timeout=1.0)
+    who_lines = [l for l in lines if "352" in l]
+    assert len(who_lines) == 1
+    # Channel should be * since claude is not in any channel
+    assert "* claude" in who_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_whois_no_channels(server, make_client):
+    """WHOIS for user not in any channel omits RPL_WHOISCHANNELS."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("WHOIS testserv-claude")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "311" in joined
+    assert "319" not in joined  # No RPL_WHOISCHANNELS
+    assert "318" in joined

--- a/tests/test_events_basic.py
+++ b/tests/test_events_basic.py
@@ -1,0 +1,284 @@
+"""End-to-end: `emit_event` surfaces a tagged PRIVMSG from `system-<server>`."""
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from agentirc.config import ServerConfig
+from agentirc.ircd import IRCd
+from agentirc.skill import Event, EventType
+from tests.conftest import IRCTestClient
+
+
+@pytest.mark.asyncio
+async def test_event_nick_from_event_field_populates_payload(server, make_client):
+    """Emitters that set Event.nick (not data['nick']) still produce correct
+    payload + body — payload.setdefault('nick', event.nick) covers them."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("CAP")
+    await c.send("JOIN #system")
+    await c.recv_until("366")
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)
+
+    ev = Event(
+        type=EventType.JOIN,
+        channel="#general",
+        nick="testserv-bob",
+        data={},  # NO data['nick'] — only Event.nick
+    )
+    await server.emit_event(ev)
+
+    collected = await c.recv_until("event=user.join")
+    assert "testserv-bob joined" in collected  # template rendered actor
+    # Find the tagged system PRIVMSG line among potentially multiple received lines.
+    # Bots may also send untagged PRIVMSGs to the channel around the same time.
+    tagged_line = next(
+        (ln for ln in collected.split("\r\n") if ln.startswith("@") and "event=user.join" in ln),
+        None,
+    )
+    assert tagged_line is not None, f"Could not find tagged event line in: {collected!r}"
+    tags = tagged_line.split(" ", 1)[0][1:]  # strip leading @
+    data_piece = [p for p in tags.split(";") if p.startswith("event-data=")][0]
+    decoded = json.loads(base64.b64decode(data_piece.split("=", 1)[1]))
+    assert decoded["nick"] == "testserv-bob"
+
+
+@pytest.mark.asyncio
+async def test_unserializable_payload_does_not_crash(server, make_client):
+    """An event with a non-JSON-serializable value surfaces with empty payload
+    rather than crashing emit_event."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("CAP")
+    await c.send("JOIN #system")
+    await c.recv_until("366")
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)
+
+    class Unserializable:
+        pass
+
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="system-testserv",
+        data={"nick": "testserv-bob", "obj": Unserializable()},
+    )
+    # Must not raise.
+    await server.emit_event(ev)
+
+    line = await c.recv_until("event=agent.connect")
+    # Body still rendered correctly (Unserializable wasn't needed for render)
+    assert "testserv-bob connected" in line
+    # Payload is empty (encoded {}) — confirm no Unserializable repr leaked
+    assert "Unserializable" not in line
+
+
+@pytest.mark.asyncio
+async def test_event_surfaces_as_tagged_privmsg(server, make_client):
+    """A tag-capable client in #system receives a tagged PRIVMSG on emit_event."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("ACK")
+    await c.send("JOIN #system")
+    # Drain all JOIN responses including the join-event PRIVMSG that fires immediately.
+    await c.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSG
+
+    # Simulate a server-originated event.
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="system-testserv",
+        data={"nick": "testserv-bob"},
+    )
+    await server.emit_event(ev)
+
+    line = await c.recv_until("agent.connect")
+    assert line.startswith("@") or "@event=" in line
+    assert "event=agent.connect" in line
+    assert "event-data=" in line
+    assert ":system-testserv!" in line
+    assert " PRIVMSG #system :" in line
+    assert "testserv-bob connected" in line
+
+
+@pytest.mark.asyncio
+async def test_channel_scoped_event_goes_to_system(server, make_client):
+    """All events — including channel-scoped ones — route to #system."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("ACK")
+    await c.send("JOIN #system")
+    # Drain all JOIN responses including the immediate join-event PRIVMSG.
+    await c.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSGs
+
+    ev = Event(
+        type=EventType.JOIN,
+        channel="#general",
+        nick="testserv-bob",
+        data={"nick": "testserv-bob"},
+    )
+    await server.emit_event(ev)
+
+    line = await c.recv_until("event=user.join")
+    assert " PRIVMSG #system :" in line
+    # EventType.JOIN.value is "user.join"
+    assert "event=user.join" in line
+
+
+@pytest.mark.asyncio
+async def test_event_data_is_base64_json(server, make_client):
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("ACK")
+    await c.send("JOIN #system")
+    # Drain all JOIN responses including the immediate join-event PRIVMSG.
+    await c.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSGs
+
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="system-testserv",
+        data={"nick": "testserv-bob"},
+    )
+    await server.emit_event(ev)
+
+    line = await c.recv_until("agent.connect")
+    # Extract the tag block from the received line(s)
+    for raw_line in line.split("\r\n"):
+        if "agent.connect" in raw_line:
+            line = raw_line
+            break
+    if line.startswith("@"):
+        tags = line.split(" ", 1)[0][1:]
+    else:
+        # find the @ block in the line
+        at_idx = line.find("@")
+        space_idx = line.find(" ", at_idx)
+        tags = line[at_idx + 1 : space_idx]
+    data_piece = [p for p in tags.split(";") if p.startswith("event-data=")][0]
+    b64 = data_piece.split("=", 1)[1]
+    decoded = json.loads(base64.b64decode(b64))
+    assert decoded["nick"] == "testserv-bob"
+
+
+@pytest.mark.asyncio
+async def test_federated_event_uses_origin_prefix(server, make_client):
+    """An event with _origin set surfaces with system-<origin> prefix.
+
+    This locks in the contract Task 12 (SEVENT federation relay) will
+    consume on the receive side: federated events surface locally with
+    the originating peer's system user as the message source.
+    """
+    c = await make_client("testserv-alice", "alice")
+    await c.send("CAP REQ :message-tags")
+    await c.recv_until("ACK")
+    await c.send("JOIN #system")
+    await c.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSG
+
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="alpha-bob",
+        data={"_origin": "alpha", "nick": "alpha-bob"},
+    )
+    await server.emit_event(ev)
+
+    line = await c.recv_until("event=agent.connect")
+    assert ":system-alpha!system@alpha" in line
+    # Internal _-prefixed keys are NOT in the encoded payload
+    assert "_origin" not in line
+
+
+@pytest.mark.asyncio
+async def test_server_wake_emitted_on_start(server):
+    """server.wake is emitted during IRCd.start() and recorded in _event_log.
+
+    We assert via _event_log introspection rather than HISTORY RECENT because
+    HistorySkill only stores MESSAGE events (Task 13 extends it to lifecycle
+    events). The _event_log is the canonical emission record: every event that
+    passes through emit_event() is appended here unconditionally.
+    """
+    wake_events = [ev for _seq, ev in server._event_log if ev.type == EventType.SERVER_WAKE]
+    assert wake_events, "Expected at least one SERVER_WAKE event in _event_log after start()"
+    ev = wake_events[0]
+    assert ev.channel is None
+    assert ev.data.get("server") == server.config.name
+
+
+@pytest.mark.asyncio
+async def test_server_sleep_emitted_on_stop(tmp_path):
+    """server.sleep surfaces as a tagged PRIVMSG to #system before teardown.
+
+    We construct a dedicated IRCd instance for this test rather than using the
+    shared `server` fixture because the test calls stop() itself — which would
+    leave the fixture's own teardown calling stop() a second time on an
+    already-stopped server. Using a fresh instance keeps fixture teardown
+    trivially safe and makes the test self-contained.
+
+    The test verifies both that the event is emitted AND that the surfacing
+    reaches connected clients before any socket teardown (i.e. stop() emits
+    server.sleep at the very top).
+    """
+    config = ServerConfig(name="testserv", host="127.0.0.1", port=0, webhook_port=0)
+
+    ircd = IRCd(config)
+    await ircd.start()
+    ircd.config.port = ircd._server.sockets[0].getsockname()[1]
+
+    # Connect a tag-capable client and join #system before stopping.
+    reader, writer = await asyncio.open_connection("127.0.0.1", ircd.config.port)
+    client = IRCTestClient(reader, writer)
+    await client.send("CAP REQ :message-tags")
+    await client.recv_until("CAP")
+    await client.send("NICK testserv-alice")
+    await client.send("USER alice 0 * :alice")
+    await client.recv_all(timeout=0.5)
+    await client.send("JOIN #system")
+    await client.recv_until("366")
+    await asyncio.sleep(0.05)
+    await client.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSG
+
+    # Start receiving concurrently before calling stop() so we capture the
+    # server.sleep PRIVMSG that must arrive at the top of stop() before any
+    # socket teardown. server.wait_closed() will not return until after we
+    # close the client connection.
+    recv_task = asyncio.create_task(client.recv_until("server.sleep"))
+
+    # Allow the event loop to schedule the recv task before we block in stop().
+    await asyncio.sleep(0)
+
+    # Trigger stop() — server.sleep must surface BEFORE sockets close.
+    # We close the client immediately after stop() emits the event so that
+    # server.wait_closed() can finish.
+    stop_task = asyncio.create_task(ircd.stop())
+
+    # Collect the sleep message — recv_until times out after 2s or on
+    # ConnectionError so this will not hang even if the event is never sent.
+    line = await recv_task
+
+    # Now close the client so server.wait_closed() can proceed.
+    try:
+        await client.close()
+    except Exception:
+        pass
+
+    # Wait for stop() to fully complete.
+    await stop_task
+
+    assert (
+        "event=server.sleep" in line
+    ), f"Expected server.sleep PRIVMSG before socket closed; got: {line!r}"
+    assert "testserv is shutting down" in line

--- a/tests/test_events_catalog.py
+++ b/tests/test_events_catalog.py
@@ -1,0 +1,70 @@
+"""Event type validation and render-template registry."""
+
+import pytest
+
+from agentirc.events import (
+    render_event,
+    validate_event_type,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "user.join",
+        "agent.connect",
+        "server.link",
+        "welcome-bot.greeted",
+        "a.b",
+        "triage-bot.classified",
+    ],
+)
+def test_valid_types(name):
+    assert validate_event_type(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "nodots",
+        "UPPERCASE.bad",
+        ".leadingdot",
+        "trailing.",
+        "double..dot",
+        "space in.name",
+        "!.x",
+    ],
+)
+def test_invalid_types(name):
+    assert validate_event_type(name) is False
+
+
+def test_render_builtin_user_join():
+    body = render_event("user.join", {"nick": "ori"}, channel="#general")
+    assert body == "ori joined #general"
+
+
+def test_render_builtin_agent_connect():
+    body = render_event("agent.connect", {"nick": "spark-claude"}, channel="#system")
+    assert body == "spark-claude connected"
+
+
+def test_render_unknown_type_falls_back():
+    body = render_event("unknown.thing", {"k": "v"}, channel="#x")
+    # Fallback should include the type name and the data dict.
+    assert "unknown.thing" in body
+    assert "k" in body
+    assert "v" in body
+
+
+def test_render_template_crash_falls_back(monkeypatch):
+    from agentirc import events as mod
+
+    def boom(data, channel):
+        raise RuntimeError("render broken")
+
+    monkeypatch.setitem(mod._TEMPLATES, "user.join", boom)
+    body = render_event("user.join", {"nick": "ori"}, channel="#x")
+    # Render failure falls back to raw shape, not an exception.
+    assert "user.join" in body

--- a/tests/test_events_federation.py
+++ b/tests/test_events_federation.py
@@ -1,0 +1,110 @@
+"""Events federate across linked servers via SEVENT."""
+
+import asyncio
+
+import pytest
+
+from agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_event_federates_to_peer(linked_servers, make_client_b):
+    """An event on server A is surfaced on server B's #system."""
+    alpha, _ = linked_servers
+
+    b = await make_client_b("beta-bob", "bob")
+    await b.send("CAP REQ :message-tags")
+    await b.recv_until("CAP")
+    await b.send("JOIN #system")
+    await b.recv_until("JOIN")
+
+    # Emit on alpha.
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="system-alpha",
+        data={"nick": "alpha-claude"},
+    )
+    await alpha.emit_event(ev)
+
+    line = await b.recv_until("event=agent.connect")
+    # Origin in the nick is alpha, not beta.
+    assert ":system-alpha!" in line
+    assert "alpha-claude connected" in line
+
+
+@pytest.mark.asyncio
+async def test_federated_event_does_not_loop(linked_servers, make_client_a, make_client_b):
+    """A federated event surfaces once on each side — no loop."""
+    alpha, _ = linked_servers
+
+    a = await make_client_a("alpha-alice", "alice")
+    await a.send("CAP REQ :message-tags")
+    await a.recv_until("CAP")
+    await a.send("JOIN #system")
+    await a.recv_until("JOIN")
+
+    b = await make_client_b("beta-bob", "bob")
+    await b.send("CAP REQ :message-tags")
+    await b.recv_until("CAP")
+    await b.send("JOIN #system")
+    await b.recv_until("JOIN")
+
+    await alpha.emit_event(
+        Event(
+            type=EventType.AGENT_CONNECT,
+            channel=None,
+            nick="system-alpha",
+            data={"nick": "alpha-claude"},
+        )
+    )
+
+    # Each side sees exactly one PRIVMSG line mentioning the event.
+    a_count = await a.count_until_idle("event=agent.connect", seconds=1.0)
+    b_count = await b.count_until_idle("event=agent.connect", seconds=1.0)
+    assert a_count == 1
+    assert b_count == 1
+
+
+@pytest.mark.asyncio
+async def test_server_link_in_event_log(linked_servers):
+    """server.link events land in both servers' _event_log after handshake."""
+    alpha, beta = linked_servers
+
+    alpha_link_events = [e for (_, e) in alpha._event_log if e.type == EventType.SERVER_LINK]
+    beta_link_events = [e for (_, e) in beta._event_log if e.type == EventType.SERVER_LINK]
+
+    assert len(alpha_link_events) >= 1, "alpha should have at least one server.link event"
+    assert len(beta_link_events) >= 1, "beta should have at least one server.link event"
+
+    # The event on alpha should mention beta as peer
+    alpha_peers = {e.data.get("peer") for e in alpha_link_events}
+    assert "beta" in alpha_peers
+
+    # The event on beta should mention alpha as peer
+    beta_peers = {e.data.get("peer") for e in beta_link_events}
+    assert "alpha" in beta_peers
+
+
+@pytest.mark.asyncio
+async def test_server_unlink_on_disconnect(linked_servers):
+    """server.unlink is emitted when a peer link drops."""
+    alpha, _ = linked_servers
+
+    # Grab the link object and close it from alpha's side
+    link = alpha.links["beta"]
+    link.writer.close()
+    try:
+        await link.writer.wait_closed()
+    except ConnectionError:
+        pass
+
+    # Wait for cleanup to propagate
+    for _ in range(50):
+        if "beta" not in alpha.links:
+            break
+        await asyncio.sleep(0.05)
+
+    unlink_events = [e for (_, e) in alpha._event_log if e.type == EventType.SERVER_UNLINK]
+    assert len(unlink_events) >= 1, "Expected server.unlink in alpha's event log"
+    assert unlink_events[0].data.get("peer") == "beta"

--- a/tests/test_events_history.py
+++ b/tests/test_events_history.py
@@ -1,0 +1,64 @@
+"""Events appear in HISTORY RECENT replays."""
+
+import asyncio
+
+import pytest
+
+from agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_event_appears_in_history(server, make_client):
+    """A global event (agent.connect) appears in #system HISTORY RECENT."""
+    alice = await make_client("testserv-alice", "alice")
+    await alice.send("CAP REQ :message-tags")
+    await alice.recv_until("CAP")
+
+    # Emit an event before the client joins #system.
+    await server.emit_event(
+        Event(
+            type=EventType.AGENT_CONNECT,
+            channel=None,
+            nick="system-testserv",
+            data={"nick": "testserv-claude"},
+        )
+    )
+
+    await alice.send("JOIN #system")
+    await alice.recv_until("JOIN")
+    # Flush any surfaced PRIVMSGs from the join
+    await asyncio.sleep(0.05)
+    await alice.recv_all(timeout=0.2)
+
+    await alice.send("HISTORY RECENT #system 50")
+    history = await alice.recv_until("HISTORYEND")
+    assert "testserv-claude connected" in history
+
+
+@pytest.mark.asyncio
+async def test_channel_event_in_channel_history(server, make_client):
+    """A channel-scoped event (room.create) appears in that channel's history."""
+    alice = await make_client("testserv-alice", "alice")
+    await alice.send("CAP REQ :message-tags")
+    await alice.recv_until("CAP")
+    await alice.send("JOIN #room")
+    await alice.recv_until("JOIN")
+    # Flush join-related messages
+    await asyncio.sleep(0.05)
+    await alice.recv_all(timeout=0.2)
+
+    await server.emit_event(
+        Event(
+            type=EventType.ROOM_CREATE,
+            channel="#room",
+            nick="testserv-bob",
+            data={"nick": "testserv-bob", "room": "#room"},
+        )
+    )
+
+    # Wait for event to be processed
+    await asyncio.sleep(0.05)
+
+    await alice.send("HISTORY RECENT #room 50")
+    history = await alice.recv_until("HISTORYEND")
+    assert "created room #room" in history

--- a/tests/test_events_lifecycle.py
+++ b/tests/test_events_lifecycle.py
@@ -1,0 +1,343 @@
+"""Integration tests for lifecycle event emission via user modes +A and +C.
+
+Design decision (Option B): Separate user modes +A (agent) and +C (console)
+trigger lifecycle events, rather than ICON values. ICON retains its display-only
+role unchanged.
+
+Event emission contract:
+- +A transition OFF→ON: emit agent.connect
+- -A transition ON→OFF, or client with +A disconnects: emit agent.disconnect
+- +C transition OFF→ON: emit console.open
+- -C transition ON→OFF, or client with +C disconnects: emit console.close
+- +H and +B are plain mode tags; they do NOT emit events.
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from tests.conftest import IRCTestClient
+
+
+def _decode_event_payload(lines: str) -> dict:
+    """Extract and decode the IRCv3 `event-data=<b64-json>` tag.
+
+    ``lines`` is multi-line text as returned by ``recv_until``; scan each
+    line for the ``@event=...`` tag blob and decode the matching
+    ``event-data=`` value. Only tagged PRIVMSG-style lines start with ``@``.
+    """
+    for raw in lines.split("\r\n"):
+        if not raw.startswith("@"):
+            continue
+        space_idx = raw.find(" ")
+        if space_idx == -1:
+            continue
+        tag_blob = raw[1:space_idx]
+        for piece in tag_blob.split(";"):
+            if piece.startswith("event-data="):
+                return json.loads(base64.b64decode(piece.split("=", 1)[1]))
+    raise AssertionError(f"No event-data tag found in lines: {lines!r}")
+
+
+async def _setup_observer(make_client) -> IRCTestClient:
+    """Connect alice to #system with message-tags CAP, draining join noise."""
+    alice = await make_client("testserv-alice", "alice")
+    await alice.send("CAP REQ :message-tags")
+    await alice.recv_until("ACK")
+    await alice.send("JOIN #system")
+    await alice.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await alice.recv_all(timeout=0.2)  # flush join-event PRIVMSG
+    return alice
+
+
+@pytest.mark.asyncio
+async def test_agent_connect_on_mode_a(server, make_client):
+    """MODE +A causes agent.connect to be delivered to #system subscribers."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +A")
+
+    line = await alice.recv_until("event=agent.connect")
+    assert "event=agent.connect" in line, f"Expected agent.connect, got: {line!r}"
+    assert "testserv-bob connected" in line
+
+
+@pytest.mark.asyncio
+async def test_agent_disconnect_on_mode_minus_a(server, make_client):
+    """MODE -A after +A causes agent.disconnect to be delivered."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +A")
+    await alice.recv_until("event=agent.connect")
+    await alice.recv_all(timeout=0.1)  # drain any trailing lines
+
+    await bob.send("MODE testserv-bob -A")
+    line = await alice.recv_until("event=agent.disconnect")
+    assert "event=agent.disconnect" in line, f"Expected agent.disconnect, got: {line!r}"
+    assert "testserv-bob disconnected" in line
+
+
+@pytest.mark.asyncio
+async def test_agent_disconnect_on_close(server, make_client):
+    """A client with +A that closes the TCP connection triggers agent.disconnect."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +A")
+    await alice.recv_until("event=agent.connect")
+    await alice.recv_all(timeout=0.1)
+
+    await bob.close()
+
+    line = await alice.recv_until("event=agent.disconnect")
+    assert "event=agent.disconnect" in line, f"Expected agent.disconnect on close, got: {line!r}"
+    assert "testserv-bob disconnected" in line
+
+
+@pytest.mark.asyncio
+async def test_console_open_on_mode_c(server, make_client):
+    """MODE +C causes console.open to be delivered to #system subscribers."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +C")
+
+    line = await alice.recv_until("event=console.open")
+    assert "event=console.open" in line, f"Expected console.open, got: {line!r}"
+    assert "testserv-bob opened a console" in line
+
+
+@pytest.mark.asyncio
+async def test_console_close_on_mode_minus_c(server, make_client):
+    """MODE -C after +C causes console.close to be delivered."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +C")
+    await alice.recv_until("event=console.open")
+    await alice.recv_all(timeout=0.1)
+
+    await bob.send("MODE testserv-bob -C")
+    line = await alice.recv_until("event=console.close")
+    assert "event=console.close" in line, f"Expected console.close, got: {line!r}"
+    assert "testserv-bob closed their console" in line
+
+
+@pytest.mark.asyncio
+async def test_console_close_on_disconnect(server, make_client):
+    """A client with +C that closes the TCP connection triggers console.close."""
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +C")
+    await alice.recv_until("event=console.open")
+    await alice.recv_all(timeout=0.1)
+
+    await bob.close()
+
+    line = await alice.recv_until("event=console.close")
+    assert "event=console.close" in line, f"Expected console.close on close, got: {line!r}"
+    assert "testserv-bob closed their console" in line
+
+
+@pytest.mark.asyncio
+async def test_h_and_b_modes_do_not_emit_events(server, make_client):
+    """Modes +H and +B are plain identity tags that do NOT emit any lifecycle events.
+
+    The test sends both mode changes and then waits briefly. No event= PRIVMSG
+    should arrive. recv_until times out and returns an empty-or-non-matching string,
+    which we verify contains no event= tag.
+    """
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +H")
+    await bob.send("MODE testserv-bob +B")
+
+    # Give the server a moment to process both MODEs
+    await asyncio.sleep(0.15)
+
+    # recv_until returns accumulated lines or "" if not found within timeout
+    # We want a short wait here — wrap in a short timeout
+    collected = []
+    try:
+        async with asyncio.timeout(0.5):
+            while True:
+                line = await alice.recv()
+                collected.append(line)
+    except (asyncio.TimeoutError, TimeoutError, ConnectionError):
+        pass
+
+    result = " ".join(collected)
+    assert (
+        "event=" not in result
+    ), f"Unexpected event delivery for +H/+B modes. Received: {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_agent_mode_idempotent(server, make_client):
+    """Sending MODE +A twice only fires agent.connect once.
+
+    Invariant: the event is triggered on the OFF→ON edge only. A second +A
+    when +A is already set is a no-op — the mode bit is already set, so there
+    is no state transition and no event is emitted.
+
+    This is the correct IRC semantics for idempotent mode changes and prevents
+    duplicate connect notifications on reconnect races.
+    """
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    # First +A: should emit
+    await bob.send("MODE testserv-bob +A")
+    line = await alice.recv_until("event=agent.connect")
+    assert "event=agent.connect" in line
+
+    # Clear any trailing lines
+    await alice.recv_all(timeout=0.1)
+
+    # Second +A: already set, no edge, no event
+    await bob.send("MODE testserv-bob +A")
+    await asyncio.sleep(0.15)
+
+    collected = []
+    try:
+        async with asyncio.timeout(0.5):
+            while True:
+                line2 = await alice.recv()
+                collected.append(line2)
+    except (asyncio.TimeoutError, TimeoutError, ConnectionError):
+        pass
+
+    result = " ".join(collected)
+    assert (
+        "event=agent.connect" not in result
+    ), f"agent.connect fired on second +A (should be idempotent). Got: {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_console_mode_hc_combined_emits_console_open_only(server, make_client):
+    """Console clients send `MODE <nick> +HC` in one message (human + console).
+
+    The combined mode string must:
+    - Set both +H and +C on the client.
+    - Emit `console.open` exactly once (the +C edge).
+    - NOT emit any event for +H (no such event type).
+
+    Mirrors the exact wire format produced by `culture.console.client`.
+    """
+    alice = await _setup_observer(make_client)
+    bob = await make_client("testserv-bob", "bob")
+
+    await bob.send("MODE testserv-bob +HC")
+
+    line = await alice.recv_until("event=console.open")
+    assert "event=console.open" in line, f"Expected console.open from +HC, got: {line!r}"
+    assert "testserv-bob opened a console" in line
+    # No agent.connect leaked into the same batch.
+    assert "event=agent.connect" not in line
+    # Give the server a moment; no further events should fire for +H.
+    await asyncio.sleep(0.1)
+    tail = await alice.recv_all(timeout=0.2)
+    tail_joined = " ".join(tail)
+    assert "event=" not in tail_joined, f"Unexpected trailing event after +HC: {tail_joined!r}"
+
+
+@pytest.mark.asyncio
+async def test_mode_before_registration_does_not_emit_events(server, make_client):
+    """Pre-registration MODE +A must not inject agent.connect.
+
+    A socket that has sent NICK but not USER is not yet registered. The server
+    must not emit lifecycle events on its behalf — otherwise any client that
+    opens a TCP connection and sends NICK+MODE can forge agent.connect /
+    console.open into #system.
+    """
+    alice = await _setup_observer(make_client)
+
+    # Half-open client: NICK only, no USER -> not registered.
+    import asyncio as _asyncio
+
+    reader, writer = await _asyncio.open_connection("127.0.0.1", server.config.port)
+    bob_raw = IRCTestClient(reader, writer)
+    await bob_raw.send("NICK testserv-bob")
+    await bob_raw.send("MODE testserv-bob +A")
+    # Give the server time to process (and, if buggy, emit).
+    await _asyncio.sleep(0.2)
+    await bob_raw.recv_all(timeout=0.2)
+
+    # Alice should see nothing.
+    tail = await alice.recv_all(timeout=0.3)
+    tail_joined = " ".join(tail)
+    assert (
+        "event=agent.connect" not in tail_joined
+    ), f"agent.connect fired pre-registration (security bug). Got: {tail_joined!r}"
+
+    await bob_raw.close()
+
+
+@pytest.mark.asyncio
+async def test_room_create_emitted_on_roomcreate(server, make_client):
+    """ROOMCREATE emits a distinct `room.create` event, separate from room.meta.
+
+    room.create signals the room's birth (a lifecycle moment); the follow-up
+    room.meta carries the initial metadata snapshot. Downstream consumers
+    (bots, history, federation peers) see both and can pick whichever semantic
+    fits their logic.
+    """
+    creator = await make_client("testserv-creator", "creator")
+    await creator.send("CAP REQ :message-tags")
+    await creator.recv_until("ACK")
+    # Events now route to #system, so join it to observe them.
+    await creator.send("JOIN #system")
+    await creator.recv_until("366")
+    await asyncio.sleep(0.05)
+    await creator.recv_all(timeout=0.2)
+
+    # Create a managed room. Events surface in #system, not the new channel.
+    await creator.send("ROOMCREATE #research :purpose=AI research;tags=ai;persistent=true")
+
+    line = await creator.recv_until("event=room.create")
+    assert "event=room.create" in line, f"Expected room.create tag, got: {line!r}"
+    assert "testserv-creator created room #research" in line
+
+    # Lock the structured payload fields downstream consumers rely on.
+    payload = _decode_event_payload(line)
+    assert payload["nick"] == "testserv-creator"
+    assert payload["purpose"] == "AI research"
+    # room_id is generated server-side — shape check only (starts with "R").
+    assert payload["room_id"].startswith(
+        "R"
+    ), f"Expected room_id to start with R, got: {payload['room_id']!r}"
+    # The server enriches the payload with the channel when the event is
+    # channel-scoped (see IRCd._build_event_payload).
+    assert payload["channel"] == "#research"
+
+
+@pytest.mark.asyncio
+async def test_room_create_precedes_room_meta(server, make_client):
+    """room.create must precede room.meta on the wire so downstream consumers
+    can distinguish creation from subsequent metadata updates."""
+    creator = await make_client("testserv-creator", "creator")
+    await creator.send("CAP REQ :message-tags")
+    await creator.recv_until("ACK")
+    # Events now route to #system, so join it to observe them.
+    await creator.send("JOIN #system")
+    await creator.recv_until("366")
+    await asyncio.sleep(0.05)
+    await creator.recv_all(timeout=0.2)
+
+    await creator.send("ROOMCREATE #ordering :purpose=Test;persistent=true")
+    collected = await creator.recv_until("event=room.meta")
+    create_idx = collected.find("event=room.create")
+    meta_idx = collected.find("event=room.meta")
+    assert create_idx != -1, f"room.create not found in: {collected!r}"
+    assert meta_idx != -1, f"room.meta not found in: {collected!r}"
+    assert create_idx < meta_idx, (
+        f"room.create must precede room.meta (create@{create_idx}, meta@{meta_idx}) "
+        f"in: {collected!r}"
+    )

--- a/tests/test_events_reserved_nick.py
+++ b/tests/test_events_reserved_nick.py
@@ -1,0 +1,68 @@
+"""Clients cannot take nicks starting with `system-`."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_reserved_nick_rejected(server, make_client):
+    c = await make_client("testserv-alice")
+    await c.send("NICK system-testserv")
+    line = await c.recv()
+    assert "432" in line
+    assert "system-testserv" in line
+
+
+@pytest.mark.asyncio
+async def test_reserved_nick_rejected_for_any_server(server, make_client):
+    c = await make_client("testserv-alice")
+    for target in ["system-thor", "system-spark-welcome", "system-foo-bar-baz"]:
+        await c.send(f"NICK {target}")
+        line = await c.recv()
+        assert "432" in line
+
+
+@pytest.mark.asyncio
+async def test_normal_nick_still_accepted(server, make_client):
+    c = await make_client("testserv-alice")
+    # Valid culture nick must still be accepted post-connect.
+    await c.send("NICK testserv-alice2")
+    # Successful nick change doesn't generate a response in this implementation.
+    # Verify no error by trying to receive with a short timeout.
+    lines = await c.recv_all(timeout=0.2)
+    # Should be no error responses (no 432, 433, etc.)
+    for line in lines:
+        assert "432" not in line
+        assert "433" not in line
+
+
+@pytest.mark.asyncio
+async def test_reserved_nick_rejected_after_registration(server, make_client):
+    c = await make_client("testserv-alice", "alice")
+    # Client is now registered (make_client with both nick and user drains welcome messages)
+    await c.send("NICK system-testserv")
+    line = await c.recv()
+    assert "432" in line
+    assert "system-testserv" in line
+
+
+@pytest.mark.asyncio
+async def test_system_user_exists(server, make_client):
+    """A `system-<servername>` virtual user is registered on server start."""
+    c = await make_client("testserv-alice")
+    await c.send("WHOIS system-testserv")
+    reply = await c.recv_until("318")  # RPL_ENDOFWHOIS
+    assert "system-testserv" in reply
+    assert "311" in reply  # RPL_WHOISUSER — user exists
+
+
+@pytest.mark.asyncio
+async def test_system_channel_exists(server, make_client):
+    """`#system` exists and system-<server> is a member."""
+    c = await make_client("testserv-alice")
+    await c.send("LIST #system")
+    reply = await c.recv_until("323")
+    assert "#system" in reply
+
+    await c.send("NAMES #system")
+    names = await c.recv_until("366")
+    assert "system-testserv" in names

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -32,7 +32,7 @@ async def test_server_link_bad_password():
         name="beta",
         host="127.0.0.1",
         port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password="correct")],
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password="correct")],  # NOSONAR S2068 — test fixture for bad-password rejection assertion
     )
 
     server_a = IRCd(config_a)
@@ -100,7 +100,7 @@ async def test_server_link_duplicate_name_rejected():
 @pytest.mark.asyncio
 async def test_squit_cleans_up_link(linked_servers):
     """SQUIT removes link."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
     assert "beta" in server_a.links
 
     link = server_a.links["beta"]
@@ -118,7 +118,7 @@ async def test_squit_cleans_up_link(linked_servers):
 @pytest.mark.asyncio
 async def test_burst_sends_local_clients(linked_servers, make_client_a):
     """Remote clients populated after link when clients exist before linking."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     # Create a client on server A
     await make_client_a(nick="alpha-alice", user="alice")
@@ -133,7 +133,7 @@ async def test_burst_sends_local_clients(linked_servers, make_client_a):
 @pytest.mark.asyncio
 async def test_burst_sends_channel_membership(linked_servers, make_client_a):
     """Remote clients appear in channels after burst."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -150,7 +150,7 @@ async def test_burst_sends_channel_membership(linked_servers, make_client_a):
 @pytest.mark.asyncio
 async def test_burst_sends_channel_topic(linked_servers, make_client_a):
     """Topic synced across servers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -166,7 +166,7 @@ async def test_burst_sends_channel_topic(linked_servers, make_client_a):
 @pytest.mark.asyncio
 async def test_remote_client_appears_in_names(linked_servers, make_client_a, make_client_b):
     """NAMES shows remote nicks."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -187,7 +187,7 @@ async def test_remote_client_appears_in_names(linked_servers, make_client_a, mak
 @pytest.mark.asyncio
 async def test_remote_client_appears_in_who(linked_servers, make_client_a, make_client_b):
     """WHO shows remote nicks."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -209,7 +209,7 @@ async def test_remote_client_appears_in_who(linked_servers, make_client_a, make_
 @pytest.mark.asyncio
 async def test_remote_client_appears_in_whois(linked_servers, make_client_a, make_client_b):
     """WHOIS works for remote clients, shows remote server name."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     await make_client_a(nick="alpha-alice", user="alice")
     await asyncio.sleep(0.3)
@@ -218,7 +218,7 @@ async def test_remote_client_appears_in_whois(linked_servers, make_client_a, mak
     await client_b.send("WHOIS alpha-alice")
     resp = await client_b.recv_all(timeout=0.5)
 
-    # 311 = RPL_WHOISUSER
+    # 311 (RPL_WHOISUSER)  # NOSONAR S125
     whois_user = [l for l in resp if " 311 " in l]
     assert whois_user, f"No WHOISUSER reply: {resp}"
     assert "alpha-alice" in whois_user[0]
@@ -237,7 +237,7 @@ async def test_remote_client_appears_in_whois(linked_servers, make_client_a, mak
 @pytest.mark.asyncio
 async def test_privmsg_relayed_to_remote_channel(linked_servers, make_client_a, make_client_b):
     """A sends PRIVMSG to #test, B receives it."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -260,7 +260,7 @@ async def test_privmsg_relayed_to_remote_channel(linked_servers, make_client_a, 
 @pytest.mark.asyncio
 async def test_privmsg_dm_to_remote_nick(linked_servers, make_client_a, make_client_b):
     """DM across servers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await asyncio.sleep(0.3)
@@ -279,7 +279,7 @@ async def test_privmsg_dm_to_remote_nick(linked_servers, make_client_a, make_cli
 @pytest.mark.asyncio
 async def test_notice_relayed(linked_servers, make_client_a, make_client_b):
     """NOTICE across servers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -302,7 +302,7 @@ async def test_notice_relayed(linked_servers, make_client_a, make_client_b):
 @pytest.mark.asyncio
 async def test_join_relayed(linked_servers, make_client_a, make_client_b):
     """JOIN visible to remote members."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_b = await make_client_b(nick="beta-bob", user="bob")
     await client_b.send("JOIN #test")
@@ -322,7 +322,7 @@ async def test_join_relayed(linked_servers, make_client_a, make_client_b):
 @pytest.mark.asyncio
 async def test_part_relayed(linked_servers, make_client_a, make_client_b):
     """PART visible to remote members."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -345,7 +345,7 @@ async def test_part_relayed(linked_servers, make_client_a, make_client_b):
 @pytest.mark.asyncio
 async def test_quit_relayed(linked_servers, make_client_a, make_client_b):
     """QUIT visible, RemoteClient removed."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -371,7 +371,7 @@ async def test_quit_relayed(linked_servers, make_client_a, make_client_b):
 @pytest.mark.asyncio
 async def test_topic_change_relayed(linked_servers, make_client_a, make_client_b):
     """TOPIC visible across servers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -392,7 +392,7 @@ async def test_topic_change_relayed(linked_servers, make_client_a, make_client_b
 @pytest.mark.asyncio
 async def test_no_relay_loop(linked_servers, make_client_a, make_client_b):
     """Message from B relayed to A is NOT sent back to B."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")
@@ -826,7 +826,7 @@ async def test_history_includes_backfilled_messages():
 @pytest.mark.asyncio
 async def test_three_way_conversation(linked_servers, make_client_a, make_client_b):
     """Clients on both servers chat back and forth."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #chat")
@@ -854,7 +854,7 @@ async def test_three_way_conversation(linked_servers, make_client_a, make_client
 @pytest.mark.asyncio
 async def test_remote_client_mentioned(linked_servers, make_client_a, make_client_b):
     """@mention across servers sends NOTICE."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #test")

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,0 +1,1251 @@
+# tests/test_federation.py
+"""Layer 4: Federation tests -- server-to-server linking."""
+
+import asyncio
+
+import pytest
+import pytest_asyncio  # noqa: F401
+
+from agentirc.config import LinkConfig, ServerConfig
+from agentirc.ircd import IRCd
+from agentirc.skill import Event
+from tests.conftest import TEST_LINK_PASSWORD, IRCTestClient
+
+# =============================================================================
+# Phase 1: Handshake
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_server_link_handshake(linked_servers):
+    """Two servers link, both have each other in `links`."""
+    server_a, server_b = linked_servers
+    assert "beta" in server_a.links
+    assert "alpha" in server_b.links
+
+
+@pytest.mark.asyncio
+async def test_server_link_bad_password():
+    """Wrong password -> link rejected."""
+    config_a = ServerConfig(name="alpha", host="127.0.0.1", port=0)
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password="correct")],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, "wrong")
+        await asyncio.sleep(0.5)
+        # Link should NOT be established
+        assert "beta" not in server_a.links
+        assert "alpha" not in server_b.links
+    finally:
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_link_duplicate_name_rejected():
+    """Same server name trying to link twice -> rejected."""
+    link_password = TEST_LINK_PASSWORD
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        # First link
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        assert "beta" in server_a.links
+
+        # Second link attempt should fail
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await asyncio.sleep(0.5)
+        # Should still only have one link
+        assert len(server_a.links) <= 1
+    finally:
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_squit_cleans_up_link(linked_servers):
+    """SQUIT removes link."""
+    server_a, server_b = linked_servers
+    assert "beta" in server_a.links
+
+    link = server_a.links["beta"]
+    await link.send_raw("SQUIT alpha :Shutting down")
+    await asyncio.sleep(0.3)
+
+    assert "beta" not in server_a.links
+
+
+# =============================================================================
+# Phase 2: Burst (state sync)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_burst_sends_local_clients(linked_servers, make_client_a):
+    """Remote clients populated after link when clients exist before linking."""
+    server_a, server_b = linked_servers
+
+    # Create a client on server A
+    await make_client_a(nick="alpha-alice", user="alice")
+    await asyncio.sleep(0.3)
+
+    # Server B should have alice as a remote client
+    assert "alpha-alice" in server_b.remote_clients
+    rc = server_b.remote_clients["alpha-alice"]
+    assert rc.server_name == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_burst_sends_channel_membership(linked_servers, make_client_a):
+    """Remote clients appear in channels after burst."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    # Server B should see alice in #test
+    assert "#test" in server_b.channels
+    channel_b = server_b.channels["#test"]
+    member_nicks = {m.nick for m in channel_b.members}
+    assert "alpha-alice" in member_nicks
+
+
+@pytest.mark.asyncio
+async def test_burst_sends_channel_topic(linked_servers, make_client_a):
+    """Topic synced across servers."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await client_a.send("TOPIC #test :Hello from alpha")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    assert "#test" in server_b.channels
+    assert server_b.channels["#test"].topic == "Hello from alpha"
+
+
+@pytest.mark.asyncio
+async def test_remote_client_appears_in_names(linked_servers, make_client_a, make_client_b):
+    """NAMES shows remote nicks."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    resp = await client_b.recv_all(timeout=0.5)
+
+    # Find NAMES reply (353)
+    names_line = [l for l in resp if " 353 " in l]
+    assert names_line, f"No NAMES reply found in: {resp}"
+    names_text = names_line[0]
+    assert "alpha-alice" in names_text
+
+
+@pytest.mark.asyncio
+async def test_remote_client_appears_in_who(linked_servers, make_client_a, make_client_b):
+    """WHO shows remote nicks."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+
+    await client_b.send("WHO #test")
+    resp = await client_b.recv_all(timeout=0.5)
+
+    who_lines = [l for l in resp if " 352 " in l]
+    nicks_in_who = [l.split()[7] for l in who_lines if len(l.split()) > 7]
+    assert "alpha-alice" in nicks_in_who, f"WHO response: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_remote_client_appears_in_whois(linked_servers, make_client_a, make_client_b):
+    """WHOIS works for remote clients, shows remote server name."""
+    server_a, server_b = linked_servers
+
+    await make_client_a(nick="alpha-alice", user="alice")
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("WHOIS alpha-alice")
+    resp = await client_b.recv_all(timeout=0.5)
+
+    # 311 = RPL_WHOISUSER
+    whois_user = [l for l in resp if " 311 " in l]
+    assert whois_user, f"No WHOISUSER reply: {resp}"
+    assert "alpha-alice" in whois_user[0]
+
+    # 312 = RPL_WHOISSERVER - should show "alpha" not "beta"
+    whois_server = [l for l in resp if " 312 " in l]
+    assert whois_server, f"No WHOISSERVER reply: {resp}"
+    assert "alpha" in whois_server[0]
+
+
+# =============================================================================
+# Phase 3: Real-time relay
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_privmsg_relayed_to_remote_channel(linked_servers, make_client_a, make_client_b):
+    """A sends PRIVMSG to #test, B receives it."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    await client_a.send("PRIVMSG #test :hello from alpha")
+    await asyncio.sleep(0.3)
+    resp = await client_b.recv_all(timeout=0.5)
+
+    privmsgs = [l for l in resp if "PRIVMSG" in l and "hello from alpha" in l]
+    assert privmsgs, f"Expected PRIVMSG relay, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_privmsg_dm_to_remote_nick(linked_servers, make_client_a, make_client_b):
+    """DM across servers."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await asyncio.sleep(0.3)
+
+    await client_a.send("PRIVMSG beta-bob :secret message")
+    await asyncio.sleep(0.3)
+    resp = await client_b.recv_all(timeout=0.5)
+
+    privmsgs = [l for l in resp if "PRIVMSG" in l and "secret message" in l]
+    assert privmsgs, f"Expected DM relay, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_notice_relayed(linked_servers, make_client_a, make_client_b):
+    """NOTICE across servers."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    await client_a.send("NOTICE #test :notice from alpha")
+    await asyncio.sleep(0.3)
+    resp = await client_b.recv_all(timeout=0.5)
+
+    notices = [l for l in resp if "NOTICE" in l and "notice from alpha" in l]
+    assert notices, f"Expected NOTICE relay, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_join_relayed(linked_servers, make_client_a, make_client_b):
+    """JOIN visible to remote members."""
+    server_a, server_b = linked_servers
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    resp = await client_b.recv_all(timeout=0.5)
+    joins = [l for l in resp if "JOIN" in l and "alpha-alice" in l]
+    assert joins, f"Expected JOIN relay, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_part_relayed(linked_servers, make_client_a, make_client_b):
+    """PART visible to remote members."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    await client_a.send("PART #test :leaving")
+    await asyncio.sleep(0.3)
+    resp = await client_b.recv_all(timeout=0.5)
+
+    parts = [l for l in resp if "PART" in l and "alpha-alice" in l]
+    assert parts, f"Expected PART relay, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_quit_relayed(linked_servers, make_client_a, make_client_b):
+    """QUIT visible, RemoteClient removed."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    await client_a.send("QUIT :goodbye")
+    await asyncio.sleep(0.5)
+
+    resp = await client_b.recv_all(timeout=0.5)
+    quits = [l for l in resp if "QUIT" in l]
+    assert quits, f"Expected QUIT relay, got: {resp}"
+
+    # RemoteClient should be removed from server B
+    assert "alpha-alice" not in server_b.remote_clients
+
+
+@pytest.mark.asyncio
+async def test_topic_change_relayed(linked_servers, make_client_a, make_client_b):
+    """TOPIC visible across servers."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    await client_a.send("TOPIC #test :new topic from alpha")
+    await asyncio.sleep(0.3)
+
+    assert server_b.channels["#test"].topic == "new topic from alpha"
+
+
+@pytest.mark.asyncio
+async def test_no_relay_loop(linked_servers, make_client_a, make_client_b):
+    """Message from B relayed to A is NOT sent back to B."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    # Bob sends a message
+    await client_b.send("PRIVMSG #test :hello from beta")
+    await asyncio.sleep(0.3)
+
+    # Alice should see it
+    resp_a = await client_a.recv_all(timeout=0.5)
+    privmsgs_a = [l for l in resp_a if "PRIVMSG" in l and "hello from beta" in l]
+    assert privmsgs_a, "Alice should receive Bob's message"
+
+    # Bob should NOT receive his own message back via relay
+    resp_b = await client_b.recv_all(timeout=0.5)
+    echo_msgs = [l for l in resp_b if "PRIVMSG" in l and "hello from beta" in l]
+    assert not echo_msgs, f"Bob should NOT get echo: {resp_b}"
+
+
+# =============================================================================
+# Phase 4: Link loss
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_link_loss_removes_remote_clients(linked_servers, make_client_a, make_client_b):
+    """Drop link -> remote clients gone, local clients see QUITs."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    # Verify remote client exists
+    assert "alpha-alice" in server_b.remote_clients
+
+    # Drop link by closing A's side
+    link_a = server_a.links.get("beta")
+    if link_a:
+        link_a.writer.close()
+    await asyncio.sleep(0.5)
+
+    # Remote clients should be gone from B
+    assert "alpha-alice" not in server_b.remote_clients
+
+    # Bob should see a QUIT for alice
+    resp = await client_b.recv_all(timeout=0.5)
+    quits = [l for l in resp if "QUIT" in l]
+    assert quits, f"Expected QUIT notification, got: {resp}"
+
+
+@pytest.mark.asyncio
+async def test_link_loss_cleans_empty_channels(linked_servers, make_client_a):
+    """Channels with only remote members are removed after link loss."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #alphaonly")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    # Server B should have #alphaonly with only remote member
+    assert "#alphaonly" in server_b.channels
+
+    # Drop link
+    link_a = server_a.links.get("beta")
+    if link_a:
+        link_a.writer.close()
+    await asyncio.sleep(0.5)
+
+    # Channel should be cleaned up on B
+    assert "#alphaonly" not in server_b.channels
+
+
+@pytest.mark.asyncio
+async def test_reconnect_resyncs_state():
+    """Drop + reconnect = remote clients reappear."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        # Connect client to A
+        reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
+        tc = IRCTestClient(reader_a, writer_a)
+        await tc.send("NICK alpha-alice")
+        await tc.send("USER alice 0 * :alice")
+        await tc.recv_all(timeout=0.5)
+        await tc.send("JOIN #test")
+        await tc.recv_all(timeout=0.5)
+
+        # Link
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        assert "beta" in server_a.links
+        await asyncio.sleep(0.3)
+        assert "alpha-alice" in server_b.remote_clients
+
+        # Drop link
+        link = server_a.links.get("beta")
+        if link:
+            link.writer.close()
+        await asyncio.sleep(0.5)
+        assert "alpha-alice" not in server_b.remote_clients
+
+        # Reconnect
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.3)
+
+        # Remote clients should be back
+        assert "alpha-alice" in server_b.remote_clients
+        assert "#test" in server_b.channels
+    finally:
+        try:
+            await tc.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+# =============================================================================
+# Phase 5: History backfill
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_backfill_replays_missed_messages():
+    """Send messages during disconnect, reconnect, B has them."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        # Connect clients
+        reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
+        tc_a = IRCTestClient(reader_a, writer_a)
+        await tc_a.send("NICK alpha-alice")
+        await tc_a.send("USER alice 0 * :alice")
+        await tc_a.recv_all(timeout=0.5)
+        await tc_a.send("JOIN #test")
+        await tc_a.recv_all(timeout=0.5)
+
+        reader_b, writer_b = await asyncio.open_connection("127.0.0.1", server_b.config.port)
+        tc_b = IRCTestClient(reader_b, writer_b)
+        await tc_b.send("NICK beta-bob")
+        await tc_b.send("USER bob 0 * :bob")
+        await tc_b.recv_all(timeout=0.5)
+        await tc_b.send("JOIN #test")
+        await tc_b.recv_all(timeout=0.5)
+
+        # Link
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.3)
+
+        # Record B's last_seen_seq from A's link
+        link_b = server_b.links.get("alpha")
+        _last_seq = link_b.last_seen_seq if link_b else 0
+
+        # Drop link
+        link_a = server_a.links.get("beta")
+        if link_a:
+            link_a.writer.close()
+        await asyncio.sleep(0.5)
+
+        # Send messages while disconnected
+        await tc_a.send("PRIVMSG #test :missed message 1")
+        await tc_a.send("PRIVMSG #test :missed message 2")
+        await asyncio.sleep(0.3)
+
+        # Reconnect -- server_a reconnects to server_b
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.5)
+
+        # Bob should receive backfilled messages
+        resp = await tc_b.recv_all(timeout=1.0)
+        missed = [l for l in resp if "PRIVMSG" in l and "missed message" in l]
+        assert len(missed) >= 2, f"Expected 2 backfilled messages, got: {resp}"
+    finally:
+        try:
+            await tc_a.close()
+        except Exception:
+            pass
+        try:
+            await tc_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_duplicate():
+    """Pre-disconnect messages not re-sent."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
+        tc_a = IRCTestClient(reader_a, writer_a)
+        await tc_a.send("NICK alpha-alice")
+        await tc_a.send("USER alice 0 * :alice")
+        await tc_a.recv_all(timeout=0.5)
+        await tc_a.send("JOIN #test")
+        await tc_a.recv_all(timeout=0.5)
+
+        reader_b, writer_b = await asyncio.open_connection("127.0.0.1", server_b.config.port)
+        tc_b = IRCTestClient(reader_b, writer_b)
+        await tc_b.send("NICK beta-bob")
+        await tc_b.send("USER bob 0 * :bob")
+        await tc_b.recv_all(timeout=0.5)
+        await tc_b.send("JOIN #test")
+        await tc_b.recv_all(timeout=0.5)
+
+        # Link
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.3)
+
+        # Send a message while linked (pre-disconnect)
+        await tc_a.send("PRIVMSG #test :pre-disconnect msg")
+        await asyncio.sleep(0.3)
+        resp = await tc_b.recv_all(timeout=0.5)
+        _pre_count = len([l for l in resp if "pre-disconnect msg" in l])
+
+        # Drop and reconnect
+        link_a = server_a.links.get("beta")
+        if link_a:
+            link_a.writer.close()
+        await asyncio.sleep(0.5)
+
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.5)
+
+        # Check bob doesn't get duplicates
+        resp = await tc_b.recv_all(timeout=0.5)
+        dup_count = len([l for l in resp if "pre-disconnect msg" in l])
+        assert dup_count == 0, f"Got {dup_count} duplicate(s): {resp}"
+    finally:
+        try:
+            await tc_a.close()
+        except Exception:
+            pass
+        try:
+            await tc_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_backfill_empty_when_nothing_missed(linked_servers, make_client_a, make_client_b):
+    """Just BACKFILLEND when nothing missed."""
+    server_a, server_b = linked_servers
+    # Link is already up, nothing sent -- backfill was already exchanged during handshake
+    # This is essentially a no-op test: verify no crashes and link is stable
+    assert "beta" in server_a.links
+    assert "alpha" in server_b.links
+
+
+@pytest.mark.asyncio
+async def test_history_includes_backfilled_messages():
+    """HISTORY RECENT shows backfilled messages."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    try:
+        reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
+        tc_a = IRCTestClient(reader_a, writer_a)
+        await tc_a.send("NICK alpha-alice")
+        await tc_a.send("USER alice 0 * :alice")
+        await tc_a.recv_all(timeout=0.5)
+        await tc_a.send("JOIN #test")
+        await tc_a.recv_all(timeout=0.5)
+
+        reader_b, writer_b = await asyncio.open_connection("127.0.0.1", server_b.config.port)
+        tc_b = IRCTestClient(reader_b, writer_b)
+        await tc_b.send("NICK beta-bob")
+        await tc_b.send("USER bob 0 * :bob")
+        await tc_b.recv_all(timeout=0.5)
+        await tc_b.send("JOIN #test")
+        await tc_b.recv_all(timeout=0.5)
+
+        # Link
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        for _ in range(50):
+            if "beta" in server_a.links:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.3)
+
+        # Alice sends a message (relayed to B, stored in B's history via event)
+        await tc_a.send("PRIVMSG #test :hello world")
+        await asyncio.sleep(0.3)
+        await tc_b.recv_all(timeout=0.5)  # drain
+
+        # Bob queries history
+        await tc_b.send("HISTORY RECENT #test 10")
+        resp = await tc_b.recv_all(timeout=0.5)
+
+        history_lines = [l for l in resp if "HISTORY" in l and "hello world" in l]
+        assert history_lines, f"Expected history entry, got: {resp}"
+    finally:
+        try:
+            await tc_a.close()
+        except Exception:
+            pass
+        try:
+            await tc_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+# =============================================================================
+# Phase 6: Polish
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_three_way_conversation(linked_servers, make_client_a, make_client_b):
+    """Clients on both servers chat back and forth."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #chat")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #chat")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    # Alice -> Bob
+    await client_a.send("PRIVMSG #chat :hey bob")
+    await asyncio.sleep(0.3)
+    resp_b = await client_b.recv_all(timeout=0.5)
+    assert any("hey bob" in l for l in resp_b), f"Bob didn't get message: {resp_b}"
+
+    # Bob -> Alice
+    await client_b.send("PRIVMSG #chat :hey alice")
+    await asyncio.sleep(0.3)
+    resp_a = await client_a.recv_all(timeout=0.5)
+    assert any("hey alice" in l for l in resp_a), f"Alice didn't get message: {resp_a}"
+
+
+@pytest.mark.asyncio
+async def test_remote_client_mentioned(linked_servers, make_client_a, make_client_b):
+    """@mention across servers sends NOTICE."""
+    server_a, server_b = linked_servers
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_b.send("JOIN #test")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    # Bob mentions Alice (remote)
+    await client_b.send("PRIVMSG #test :hey @alpha-alice check this")
+    await asyncio.sleep(0.5)
+
+    resp_a = await client_a.recv_all(timeout=0.5)
+    # Alice should get either a NOTICE about the mention or the PRIVMSG with her name
+    mention_notices = [l for l in resp_a if "NOTICE" in l and "mentioned" in l]
+    privmsgs = [l for l in resp_a if "PRIVMSG" in l and "alpha-alice" in l]
+    assert mention_notices or privmsgs, f"Expected mention notification, got: {resp_a}"
+
+
+# =============================================================================
+# Phase 7: Link trust levels & channel federation modes
+# =============================================================================
+
+
+async def _make_linked_pair(*, trust: str = "full"):
+    """Helper: create two servers linked with the given trust level.
+
+    Returns (server_a, server_b) after the link handshake completes.
+    Both link configs carry the specified trust value.
+    """
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[
+            LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password, trust=trust)
+        ],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[
+            LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password, trust=trust)
+        ],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    # Update link configs with actual ports
+    config_a.links[0].port = server_b.config.port
+    config_b.links[0].port = server_a.config.port
+
+    # Server A connects to Server B (pass trust level)
+    try:
+        await server_a.connect_to_peer(
+            "127.0.0.1", server_b.config.port, link_password, trust=trust
+        )
+        for _ in range(50):
+            if "beta" in server_a.links and "alpha" in server_b.links:
+                break
+            await asyncio.sleep(0.05)
+
+        assert (
+            "beta" in server_a.links and "alpha" in server_b.links
+        ), "Server link handshake failed — link not established"
+    except Exception:
+        await server_a.stop()
+        await server_b.stop()
+        raise
+
+    return server_a, server_b
+
+
+async def _connect_client(server, nick, user):
+    """Helper: connect a test client to a server, return IRCTestClient."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)
+    client = IRCTestClient(reader, writer)
+    await client.send(f"NICK {nick}")
+    await client.send(f"USER {user} 0 * :{user}")
+    await client.recv_all(timeout=0.5)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_full_link_restricted_channel_not_relayed():
+    """Full trust link: +R channel is never federated."""
+    server_a, server_b = await _make_linked_pair(trust="full")
+
+    try:
+        # Connect Bob on server B first and join #secret
+        client_b = await _connect_client(server_b, "beta-bob", "bob")
+        await client_b.send("JOIN #secret")
+        await client_b.recv_all(timeout=0.5)
+
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #secret")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        # Set +R on #secret (restrict from federation)
+        await client_a.send("MODE #secret +R")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        # Verify +R is set locally
+        channel_a = server_a.channels.get("#secret")
+        assert channel_a is not None, "Channel should exist on server A"
+        assert channel_a.restricted, "Channel should be restricted (+R)"
+
+        # Drain Bob's buffer before sending the test message
+        await client_b.recv_all(timeout=0.5)
+
+        # Send a message to #secret
+        await client_a.send("PRIVMSG #secret :top secret info")
+        await asyncio.sleep(0.5)
+
+        # Bob should NOT have received the "top secret info" message
+        resp = await client_b.recv_all(timeout=0.5)
+        secret_msgs = [l for l in resp if "PRIVMSG" in l and "top secret info" in l]
+        assert not secret_msgs, f"Restricted channel message should NOT relay: {resp}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        try:
+            await client_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_restricted_link_no_share_not_relayed():
+    """Restricted trust link: channels without +S are NOT relayed."""
+    server_a, server_b = await _make_linked_pair(trust="restricted")
+
+    try:
+        # Connect Bob on server B first and join #general
+        client_b = await _connect_client(server_b, "beta-bob", "bob")
+        await client_b.send("JOIN #general")
+        await client_b.recv_all(timeout=0.5)
+
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #general")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        # Drain Bob's buffer
+        await client_b.recv_all(timeout=0.5)
+
+        # Send a message -- no +S is set, so nothing should cross
+        await client_a.send("PRIVMSG #general :hello from alpha")
+        await asyncio.sleep(0.5)
+
+        # Bob's #general is local to server B, should NOT have received the message
+        resp = await client_b.recv_all(timeout=0.5)
+        relayed = [l for l in resp if "PRIVMSG" in l and "hello from alpha" in l]
+        assert not relayed, f"Message should NOT relay on restricted link without +S: {resp}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        try:
+            await client_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_restricted_link_mutual_share_relayed():
+    """Restricted trust link: mutual +S enables federation for that channel."""
+    server_a, server_b = await _make_linked_pair(trust="restricted")
+
+    try:
+        # Both sides create #collab and set +S for the other server
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #collab")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.1)
+
+        client_b = await _connect_client(server_b, "beta-bob", "bob")
+        await client_b.send("JOIN #collab")
+        await client_b.recv_all(timeout=0.5)
+        await asyncio.sleep(0.1)
+
+        # Alice sets +S beta on server A's #collab
+        await client_a.send("MODE #collab +S beta")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.1)
+
+        # Bob sets +S alpha on server B's #collab
+        await client_b.send("MODE #collab +S alpha")
+        await client_b.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        # Verify +S is set on both sides
+        channel_a = server_a.channels.get("#collab")
+        assert channel_a is not None
+        assert (
+            "beta" in channel_a.shared_with
+        ), f"Server A #collab should share with beta: {channel_a.shared_with}"
+
+        channel_b = server_b.channels.get("#collab")
+        assert channel_b is not None
+        assert (
+            "alpha" in channel_b.shared_with
+        ), f"Server B #collab should share with alpha: {channel_b.shared_with}"
+
+        # Now Alice sends a message -- it should relay to Bob
+        await client_a.send("PRIVMSG #collab :shared message")
+        await asyncio.sleep(0.5)
+        resp = await client_b.recv_all(timeout=0.5)
+
+        relayed = [l for l in resp if "PRIVMSG" in l and "shared message" in l]
+        assert relayed, f"Mutual +S should enable relay on restricted link, got: {resp}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        try:
+            await client_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_restricted_link_one_sided_share_not_relayed():
+    """Restricted trust link: one-sided +S is NOT enough for relay."""
+    server_a, server_b = await _make_linked_pair(trust="restricted")
+
+    try:
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #collab")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.1)
+
+        client_b = await _connect_client(server_b, "beta-bob", "bob")
+        await client_b.send("JOIN #collab")
+        await client_b.recv_all(timeout=0.5)
+        await asyncio.sleep(0.1)
+
+        # Only server A sets +S beta -- server B does NOT set +S alpha
+        await client_a.send("MODE #collab +S beta")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        # Verify only one side has +S
+        channel_a = server_a.channels.get("#collab")
+        assert "beta" in channel_a.shared_with
+
+        channel_b = server_b.channels.get("#collab")
+        assert "alpha" not in channel_b.shared_with, "Server B should NOT have +S alpha set"
+
+        # Alice sends a message -- should NOT relay (one-sided +S)
+        await client_a.send("PRIVMSG #collab :one sided message")
+        await asyncio.sleep(0.5)
+        resp = await client_b.recv_all(timeout=0.5)
+
+        relayed = [l for l in resp if "PRIVMSG" in l and "one sided message" in l]
+        assert not relayed, f"One-sided +S should NOT enable relay on restricted link: {resp}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        try:
+            await client_b.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_new_channel_on_full_link_relayed():
+    """Full trust link: new channel created after linking is visible to peer."""
+    server_a, server_b = await _make_linked_pair(trust="full")
+
+    try:
+        # Create a new channel on server A after the link is already up
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #new-room")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.5)
+
+        # Server B should see #new-room (via SJOIN relay)
+        assert (
+            "#new-room" in server_b.channels
+        ), f"New channel should federate on full link: {list(server_b.channels.keys())}"
+
+        # Remote member should be visible
+        channel_b = server_b.channels["#new-room"]
+        member_nicks = {m.nick for m in channel_b.members}
+        assert (
+            "alpha-alice" in member_nicks
+        ), f"alpha-alice should be in #new-room on server B: {member_nicks}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_new_channel_on_restricted_link_not_relayed():
+    """Restricted trust link: new channel without +S is NOT visible to peer."""
+    server_a, server_b = await _make_linked_pair(trust="restricted")
+
+    try:
+        # Create a new channel on server A -- no +S set
+        client_a = await _connect_client(server_a, "alpha-alice", "alice")
+        await client_a.send("JOIN #new-room")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.5)
+
+        # Server B should NOT see #new-room (restricted link, no +S)
+        assert (
+            "#new-room" not in server_b.channels
+        ), f"New channel should NOT federate on restricted link: {list(server_b.channels.keys())}"
+    finally:
+        try:
+            await client_a.close()
+        except Exception:
+            pass
+        await server_a.stop()
+        await server_b.stop()
+
+
+# =============================================================================
+# Phase 8: Replay regression — issue #291
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_replay_event_handles_string_typed_message_event(linked_servers):
+    """Regression for #291: _replay_event must accept event.type as a plain
+    string (the shape produced by _parse_event_type for non-enum wire types).
+
+    Before the fix, ``event.type == EventType.MESSAGE`` returned False when
+    ``event.type`` was the string ``"message"``, so the typed fast path
+    silently skipped — a federated MESSAGE event reaching backfill replay
+    would not produce the SMSG/SNOTICE wire output.
+    """
+    server_a, _ = linked_servers
+    link_to_b = server_a.links["beta"]
+
+    captured: list[bytes] = []
+    real_write = link_to_b.writer.write
+
+    def recording_write(data):
+        captured.append(data)
+        return real_write(data)
+
+    link_to_b.writer.write = recording_write
+    try:
+        # Construct a string-typed MESSAGE event — the exact shape
+        # _parse_event_type emits.
+        event = Event(
+            type="message",  # type: ignore[arg-type] -- intentional string
+            channel=None,
+            nick="alpha-bob",
+            data={"target": "beta-charlie", "text": "ping-291"},
+        )
+        await link_to_b._replay_event(seq=42, event=event)
+    finally:
+        link_to_b.writer.write = real_write
+
+    wire = b"".join(captured).decode("utf-8", errors="replace")
+    assert (
+        " SMSG " in wire
+    ), f"expected SMSG in wire output for string-typed MESSAGE event, got: {wire!r}"
+    assert "ping-291" in wire

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -55,32 +55,16 @@ async def test_server_link_bad_password():
 
 
 @pytest.mark.asyncio
-async def test_server_link_duplicate_name_rejected():
+async def test_server_link_duplicate_name_rejected(tmp_path):
     """Same server name trying to link twice -> rejected."""
-    link_password = TEST_LINK_PASSWORD
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
+    from tests._helpers import boot_linked_pair
 
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-    await server_a.start()
-    await server_b.start()
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    link_password = TEST_LINK_PASSWORD
+    server_a, server_b = await boot_linked_pair(tmp_path, link_password=link_password)
 
     try:
         # First link
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -88,7 +72,7 @@ async def test_server_link_duplicate_name_rejected():
         assert "beta" in server_a.links
 
         # Second link attempt should fail
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         await asyncio.sleep(0.5)
         # Should still only have one link
         assert len(server_a.links) <= 1
@@ -481,29 +465,11 @@ async def test_link_loss_cleans_empty_channels(linked_servers, make_client_a):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_resyncs_state():
+async def test_reconnect_resyncs_state(tmp_path):
     """Drop + reconnect = remote clients reappear."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-    await server_a.start()
-    await server_b.start()
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    server_a, server_b = await boot_linked_pair(tmp_path)
 
     try:
         # Connect client to A
@@ -516,7 +482,7 @@ async def test_reconnect_resyncs_state():
         await tc.recv_all(timeout=0.5)
 
         # Link
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -533,7 +499,7 @@ async def test_reconnect_resyncs_state():
         assert "alpha-alice" not in server_b.remote_clients
 
         # Reconnect
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -558,29 +524,11 @@ async def test_reconnect_resyncs_state():
 
 
 @pytest.mark.asyncio
-async def test_backfill_replays_missed_messages():
+async def test_backfill_replays_missed_messages(tmp_path):
     """Send messages during disconnect, reconnect, B has them."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-    await server_a.start()
-    await server_b.start()
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    server_a, server_b = await boot_linked_pair(tmp_path)
 
     try:
         # Connect clients
@@ -601,7 +549,7 @@ async def test_backfill_replays_missed_messages():
         await tc_b.recv_all(timeout=0.5)
 
         # Link
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -624,7 +572,7 @@ async def test_backfill_replays_missed_messages():
         await asyncio.sleep(0.3)
 
         # Reconnect -- server_a reconnects to server_b
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -649,29 +597,11 @@ async def test_backfill_replays_missed_messages():
 
 
 @pytest.mark.asyncio
-async def test_backfill_does_not_duplicate():
+async def test_backfill_does_not_duplicate(tmp_path):
     """Pre-disconnect messages not re-sent."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-    await server_a.start()
-    await server_b.start()
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    server_a, server_b = await boot_linked_pair(tmp_path)
 
     try:
         reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
@@ -691,7 +621,7 @@ async def test_backfill_does_not_duplicate():
         await tc_b.recv_all(timeout=0.5)
 
         # Link
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -710,7 +640,7 @@ async def test_backfill_does_not_duplicate():
             link_a.writer.close()
         await asyncio.sleep(0.5)
 
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break
@@ -745,29 +675,11 @@ async def test_backfill_empty_when_nothing_missed(linked_servers, make_client_a,
 
 
 @pytest.mark.asyncio
-async def test_history_includes_backfilled_messages():
+async def test_history_includes_backfilled_messages(tmp_path):
     """HISTORY RECENT shows backfilled messages."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-    await server_a.start()
-    await server_b.start()
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+    server_a, server_b = await boot_linked_pair(tmp_path)
 
     try:
         reader_a, writer_a = await asyncio.open_connection("127.0.0.1", server_a.config.port)
@@ -787,7 +699,7 @@ async def test_history_includes_backfilled_messages():
         await tc_b.recv_all(timeout=0.5)
 
         # Link
-        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+        await server_a.connect_to_peer("127.0.0.1", server_b.config.port, TEST_LINK_PASSWORD)
         for _ in range(50):
             if "beta" in server_a.links:
                 break

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,553 @@
+# tests/test_history.py
+import asyncio
+import tempfile
+
+import pytest
+
+from agentirc.skills.history import HistorySkill
+
+# --- Task 4: Recording tests ---
+
+
+@pytest.mark.asyncio
+async def test_history_records_channel_messages(server, make_client):
+    skill = HistorySkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :first message")
+    await bob.recv()
+    await alice.send("PRIVMSG #test :second message")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    entries = skill.get_recent("#test", 10)
+    # 2 join lifecycle events + 2 messages = 4+ entries; check messages are present.
+    message_entries = [e for e in entries if e.nick == "testserv-alice"]
+    assert len(message_entries) == 2
+    assert message_entries[0].text == "first message"
+    assert message_entries[1].text == "second message"
+
+
+@pytest.mark.asyncio
+async def test_history_does_not_record_dms(server, make_client):
+    skill = HistorySkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("PRIVMSG testserv-bob :secret dm")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    # No channel history should exist
+    assert skill.get_recent("#test", 10) == []
+    assert skill._channels == {}
+
+
+@pytest.mark.asyncio
+async def test_history_per_channel_isolation(server, make_client):
+    skill = HistorySkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #chan1")
+    await alice.recv_all()
+    await alice.send("JOIN #chan2")
+    await alice.recv_all()
+    await bob.send("JOIN #chan1")
+    await bob.recv_all()
+    await bob.send("JOIN #chan2")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #chan1 :msg for chan1")
+    await bob.recv()
+    await alice.send("PRIVMSG #chan2 :msg for chan2")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    chan1 = skill.get_recent("#chan1", 10)
+    chan2 = skill.get_recent("#chan2", 10)
+    # Join lifecycle events are also stored; verify message isolation by nick/text.
+    assert any(e.text == "msg for chan1" for e in chan1)
+    assert not any(e.text == "msg for chan2" for e in chan1)
+    assert any(e.text == "msg for chan2" for e in chan2)
+    assert not any(e.text == "msg for chan1" for e in chan2)
+
+
+@pytest.mark.asyncio
+async def test_history_respects_max_entries(server, make_client):
+    skill = HistorySkill(maxlen=5)
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    for i in range(8):
+        await alice.send(f"PRIVMSG #test :message {i}")
+        await bob.recv()
+
+    await asyncio.sleep(0.05)
+    entries = skill.get_recent("#test", 100)
+    assert len(entries) == 5
+    # Should have the latest 5 (messages 3-7)
+    assert entries[0].text == "message 3"
+    assert entries[4].text == "message 7"
+
+
+@pytest.mark.asyncio
+async def test_history_entries_have_timestamps(server, make_client):
+    skill = HistorySkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :timestamped")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    entries = skill.get_recent("#test", 1)
+    assert len(entries) == 1
+    assert isinstance(entries[0].timestamp, float)
+    assert entries[0].timestamp > 0
+
+
+@pytest.mark.asyncio
+async def test_history_get_recent_empty_channel(server, make_client):
+    skill = HistorySkill()
+    await server.register_skill(skill)
+
+    entries = skill.get_recent("#nonexistent", 10)
+    assert entries == []
+
+
+# --- Task 5: HISTORY RECENT command tests ---
+
+
+@pytest.mark.asyncio
+async def test_history_recent_command(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    for i in range(5):
+        await alice.send(f"PRIVMSG #test :msg {i}")
+        await bob.recv()
+
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY RECENT #test 3")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    end_lines = [l for l in lines if "HISTORYEND" in l]
+
+    assert len(history_lines) == 3
+    assert len(end_lines) == 1
+    assert "msg 2" in history_lines[0]
+    assert "msg 3" in history_lines[1]
+    assert "msg 4" in history_lines[2]
+
+
+@pytest.mark.asyncio
+async def test_history_recent_includes_nick_and_timestamp(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :hello world")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY RECENT #test 1")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    assert len(history_lines) == 1
+    # Format: :server HISTORY #channel nick timestamp :text
+    line = history_lines[0]
+    assert "testserv-alice" in line
+    assert "#test" in line
+    assert "hello world" in line
+
+
+@pytest.mark.asyncio
+async def test_history_recent_empty_channel(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+
+    await alice.send("HISTORY RECENT #empty 10")
+    lines = await alice.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    end_lines = [l for l in lines if "HISTORYEND" in l]
+    assert len(history_lines) == 0
+    assert len(end_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_history_recent_count_exceeds_stored(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :only one")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY RECENT #test 100")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    # Join lifecycle events are also stored — at least 1 HISTORY line, and the
+    # message text appears somewhere among the entries.
+    assert len(history_lines) >= 1
+    assert any("only one" in l for l in history_lines)
+
+
+@pytest.mark.asyncio
+async def test_history_missing_params(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("HISTORY")
+    resp = await alice.recv()
+    assert "461" in resp  # ERR_NEEDMOREPARAMS
+
+
+@pytest.mark.asyncio
+async def test_history_recent_missing_count(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("HISTORY RECENT #test")
+    resp = await alice.recv()
+    assert "461" in resp  # ERR_NEEDMOREPARAMS
+
+
+@pytest.mark.asyncio
+async def test_history_unknown_subcommand(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("HISTORY BADCMD #test")
+    resp = await alice.recv()
+    assert "NOTICE" in resp
+    assert "Unknown HISTORY subcommand" in resp
+
+
+# --- Task 6: HISTORY SEARCH command tests ---
+
+
+@pytest.mark.asyncio
+async def test_history_search_finds_matching_messages(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :hello world")
+    await bob.recv()
+    await alice.send("PRIVMSG #test :goodbye world")
+    await bob.recv()
+    await alice.send("PRIVMSG #test :hello again")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY SEARCH #test :hello")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    end_lines = [l for l in lines if "HISTORYEND" in l]
+    assert len(history_lines) == 2
+    assert "hello world" in history_lines[0]
+    assert "hello again" in history_lines[1]
+    assert len(end_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_history_search_case_insensitive(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :Hello World")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY SEARCH #test :hello")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    assert len(history_lines) == 1
+    assert "Hello World" in history_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_history_search_no_results(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :some message")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY SEARCH #test :nonexistent")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    end_lines = [l for l in lines if "HISTORYEND" in l]
+    assert len(history_lines) == 0
+    assert len(end_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_history_search_missing_term(server, make_client):
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("HISTORY SEARCH #test")
+    resp = await alice.recv()
+    assert "461" in resp  # ERR_NEEDMOREPARAMS
+
+
+# --- Task 7: Auto-registration test ---
+
+
+@pytest.mark.asyncio
+async def test_history_auto_registered(server, make_client):
+    """Server should have history skill auto-registered."""
+    # Check that a HistorySkill exists in server.skills
+    history_skills = [s for s in server.skills if isinstance(s, HistorySkill)]
+    assert len(history_skills) == 1
+
+    # Verify HISTORY RECENT works without manual registration
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :auto registered test")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    await bob.send("HISTORY RECENT #test 5")
+    lines = await bob.recv_all(timeout=1.0)
+
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    # Join lifecycle events are also stored — verify the message appears.
+    assert any("auto registered test" in l for l in history_lines)
+
+
+# --- History store unit tests ---
+
+
+def test_history_store_append_and_get_recent():
+    from agentirc.history_store import HistoryStore
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        store = HistoryStore(data_dir)
+        store.append("#test", "alice", "first", 1000.0)
+        store.append("#test", "bob", "second", 1001.0)
+        store.append("#test", "alice", "third", 1002.0)
+
+        recent = store.get_recent("#test", 2)
+        assert len(recent) == 2
+        assert recent[0]["text"] == "second"
+        assert recent[1]["text"] == "third"
+
+        all_entries = store.get_recent("#test", 100)
+        assert len(all_entries) == 3
+        assert all_entries[0]["text"] == "first"
+
+        store.close()
+
+
+def test_history_store_search():
+    from agentirc.history_store import HistoryStore
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        store = HistoryStore(data_dir)
+        store.append("#test", "alice", "hello world", 1000.0)
+        store.append("#test", "bob", "goodbye world", 1001.0)
+        store.append("#test", "alice", "hello again", 1002.0)
+
+        results = store.search("#test", "hello")
+        assert len(results) == 2
+        assert results[0]["text"] == "hello world"
+        assert results[1]["text"] == "hello again"
+
+        no_results = store.search("#test", "nonexistent")
+        assert len(no_results) == 0
+
+        store.close()
+
+
+def test_history_store_prune():
+    import time
+
+    from agentirc.history_store import HistoryStore
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        store = HistoryStore(data_dir)
+        old_ts = time.time() - 86400 * 60  # 60 days ago
+        new_ts = time.time() - 86400 * 5  # 5 days ago
+        store.append("#test", "alice", "old message", old_ts)
+        store.append("#test", "bob", "new message", new_ts)
+
+        deleted = store.prune(30)
+        assert deleted == 1
+
+        remaining = store.get_recent("#test", 100)
+        assert len(remaining) == 1
+        assert remaining[0]["text"] == "new message"
+
+        store.close()
+
+
+def test_history_store_load_channels():
+    from agentirc.history_store import HistoryStore
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        store = HistoryStore(data_dir)
+        store.append("#general", "alice", "gen msg", 1000.0)
+        store.append("#dev", "bob", "dev msg", 1001.0)
+        store.append("#general", "carol", "gen msg 2", 1002.0)
+
+        channels = store.load_channels(100)
+        assert "#general" in channels
+        assert "#dev" in channels
+        assert len(channels["#general"]) == 2
+        assert len(channels["#dev"]) == 1
+
+        store.close()
+
+
+# --- History persistence integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_history_persists_across_restart():
+    """History should survive server restart when data_dir is configured."""
+    from agentirc.config import ServerConfig
+    from agentirc.ircd import IRCd
+    from tests.conftest import IRCTestClient
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        config = ServerConfig(name="testserv", host="127.0.0.1", port=0, data_dir=data_dir)
+
+        # Start server, send some messages
+        ircd = IRCd(config)
+        await ircd.start()
+        port = ircd._server.sockets[0].getsockname()[1]
+        ircd.config.port = port
+
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        alice = IRCTestClient(reader, writer)
+        await alice.send("NICK testserv-alice")
+        await alice.send("USER alice 0 * :alice")
+        await alice.recv_all(timeout=0.5)
+        await alice.send("JOIN #test")
+        await alice.recv_all(timeout=0.5)
+
+        reader2, writer2 = await asyncio.open_connection("127.0.0.1", port)
+        bob = IRCTestClient(reader2, writer2)
+        await bob.send("NICK testserv-bob")
+        await bob.send("USER bob 0 * :bob")
+        await bob.recv_all(timeout=0.5)
+        await bob.send("JOIN #test")
+        await bob.recv_all(timeout=0.5)
+        await alice.recv_all(timeout=0.3)
+
+        await alice.send("PRIVMSG #test :persisted message one")
+        await bob.recv()
+        await alice.send("PRIVMSG #test :persisted message two")
+        await bob.recv()
+        await asyncio.sleep(0.05)
+
+        await alice.close()
+        await bob.close()
+        await ircd.stop()
+
+        # Restart server with same data_dir
+        ircd2 = IRCd(config)
+        await ircd2.start()
+        port2 = ircd2._server.sockets[0].getsockname()[1]
+        ircd2.config.port = port2
+
+        reader3, writer3 = await asyncio.open_connection("127.0.0.1", port2)
+        carol = IRCTestClient(reader3, writer3)
+        await carol.send("NICK testserv-carol")
+        await carol.send("USER carol 0 * :carol")
+        await carol.recv_all(timeout=0.5)
+
+        # Query history — should still have the messages (plus persisted join events).
+        await carol.send("HISTORY RECENT #test 10")
+        lines = await carol.recv_all(timeout=1.0)
+        history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+        assert any("persisted message one" in l for l in history_lines)
+        assert any("persisted message two" in l for l in history_lines)
+
+        await carol.close()
+        await ircd2.stop()
+
+
+@pytest.mark.asyncio
+async def test_history_no_persistence_without_data_dir(server, make_client):
+    """History should work in-memory when data_dir is not configured."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :ephemeral message")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    # Should still work in-memory (join lifecycle events also stored).
+    await bob.send("HISTORY RECENT #test 5")
+    lines = await bob.recv_all(timeout=1.0)
+    history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
+    assert any("ephemeral message" in l for l in history_lines)

--- a/tests/test_link_reconnect.py
+++ b/tests/test_link_reconnect.py
@@ -11,42 +11,12 @@ from tests.conftest import TEST_LINK_PASSWORD
 
 
 @pytest.mark.asyncio
-async def test_link_drop_triggers_retry():
+async def test_link_drop_triggers_retry(tmp_path):
     """When a linked peer drops (non-SQUIT), the server schedules retry."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair, link_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-
-    await server_a.start()
-    await server_b.start()
-
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
-
-    # Update link configs with actual ports
-    config_a.links[0].port = server_b.config.port
-    config_b.links[0].port = server_a.config.port
-
-    # Link the servers
-    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
-    for _ in range(50):
-        if "beta" in server_a.links and "alpha" in server_b.links:
-            break
-        await asyncio.sleep(0.05)
+    server_a, server_b = await boot_linked_pair(tmp_path)
+    await link_pair(server_a, server_b)
     assert "beta" in server_a.links
 
     # Kill server B abruptly (non-SQUIT drop)
@@ -66,40 +36,12 @@ async def test_link_drop_triggers_retry():
 
 
 @pytest.mark.asyncio
-async def test_squit_does_not_trigger_retry():
+async def test_squit_does_not_trigger_retry(tmp_path):
     """When a peer sends SQUIT, no retry should be scheduled."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair, link_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-
-    await server_a.start()
-    await server_b.start()
-
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
-
-    config_a.links[0].port = server_b.config.port
-    config_b.links[0].port = server_a.config.port
-
-    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
-    for _ in range(50):
-        if "beta" in server_a.links and "alpha" in server_b.links:
-            break
-        await asyncio.sleep(0.05)
+    server_a, server_b = await boot_linked_pair(tmp_path)
+    await link_pair(server_a, server_b)
     assert "beta" in server_a.links
 
     # Have server B send SQUIT to server A (graceful delink)
@@ -122,42 +64,19 @@ async def test_squit_does_not_trigger_retry():
 
 
 @pytest.mark.asyncio
-async def test_incoming_connection_cancels_retry():
+async def test_incoming_connection_cancels_retry(tmp_path):
     """When a peer reconnects inbound while retry is pending, retry is cancelled."""
-    link_password = TEST_LINK_PASSWORD
+    from tests._helpers import boot_linked_pair, link_pair
 
-    config_a = ServerConfig(
-        name="alpha",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
-    )
-    config_b = ServerConfig(
-        name="beta",
-        host="127.0.0.1",
-        port=0,
-        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
-    )
-
-    server_a = IRCd(config_a)
-    server_b = IRCd(config_b)
-
-    await server_a.start()
-    await server_b.start()
-
-    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
-    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
-
-    config_a.links[0].port = server_b.config.port
-    config_b.links[0].port = server_a.config.port
-
-    # Link the servers (A -> B)
-    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
-    for _ in range(50):
-        if "beta" in server_a.links and "alpha" in server_b.links:
-            break
-        await asyncio.sleep(0.05)
+    server_a, server_b = await boot_linked_pair(tmp_path)
+    await link_pair(server_a, server_b)
     assert "beta" in server_a.links
+
+    # Stash config_a/b for the post-restart retry-redirect step (was in
+    # the inline boot block; now needs explicit reference for the
+    # reconnect logic that follows).
+    config_a = server_a.config
+    config_b = server_b.config
 
     # Kill server B to trigger retry on A
     await server_b.stop()
@@ -177,7 +96,7 @@ async def test_incoming_connection_cancels_retry():
     config_a.links[0].port = server_b2.config.port
 
     # B2 connects to A (inbound connection to A)
-    await server_b2.connect_to_peer("127.0.0.1", server_a.config.port, link_password)
+    await server_b2.connect_to_peer("127.0.0.1", server_a.config.port, TEST_LINK_PASSWORD)
     for _ in range(50):
         if "beta" in server_a.links:
             break

--- a/tests/test_link_reconnect.py
+++ b/tests/test_link_reconnect.py
@@ -1,0 +1,222 @@
+# tests/test_link_reconnect.py
+"""S2S link auto-reconnect tests."""
+
+import asyncio
+
+import pytest
+
+from agentirc.config import LinkConfig, ServerConfig
+from agentirc.ircd import IRCd
+from tests.conftest import TEST_LINK_PASSWORD
+
+
+@pytest.mark.asyncio
+async def test_link_drop_triggers_retry():
+    """When a linked peer drops (non-SQUIT), the server schedules retry."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    # Update link configs with actual ports
+    config_a.links[0].port = server_b.config.port
+    config_b.links[0].port = server_a.config.port
+
+    # Link the servers
+    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+    for _ in range(50):
+        if "beta" in server_a.links and "alpha" in server_b.links:
+            break
+        await asyncio.sleep(0.05)
+    assert "beta" in server_a.links
+
+    # Kill server B abruptly (non-SQUIT drop)
+    await server_b.stop()
+
+    # Wait for alpha to detect the link drop and schedule retry
+    for _ in range(50):
+        if "beta" in server_a._link_retry_state:
+            break
+        await asyncio.sleep(0.05)
+
+    assert "beta" in server_a._link_retry_state
+    assert server_a._link_retry_state["beta"]["task"] is not None
+
+    # Cleanup
+    await server_a.stop()
+
+
+@pytest.mark.asyncio
+async def test_squit_does_not_trigger_retry():
+    """When a peer sends SQUIT, no retry should be scheduled."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    config_a.links[0].port = server_b.config.port
+    config_b.links[0].port = server_a.config.port
+
+    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+    for _ in range(50):
+        if "beta" in server_a.links and "alpha" in server_b.links:
+            break
+        await asyncio.sleep(0.05)
+    assert "beta" in server_a.links
+
+    # Have server B send SQUIT to server A (graceful delink)
+    link_to_alpha = server_b.links["alpha"]
+    await link_to_alpha.send_raw("SQUIT beta :Shutting down gracefully")
+
+    # Wait for alpha to process the SQUIT and remove the link
+    for _ in range(50):
+        if "beta" not in server_a.links:
+            break
+        await asyncio.sleep(0.05)
+
+    assert "beta" not in server_a.links
+    # SQUIT should NOT trigger retry
+    assert "beta" not in server_a._link_retry_state
+
+    # Cleanup
+    await server_a.stop()
+    await server_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_incoming_connection_cancels_retry():
+    """When a peer reconnects inbound while retry is pending, retry is cancelled."""
+    link_password = TEST_LINK_PASSWORD
+
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+    )
+    config_b = ServerConfig(
+        name="beta",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    server_b = IRCd(config_b)
+
+    await server_a.start()
+    await server_b.start()
+
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+    server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+    config_a.links[0].port = server_b.config.port
+    config_b.links[0].port = server_a.config.port
+
+    # Link the servers (A -> B)
+    await server_a.connect_to_peer("127.0.0.1", server_b.config.port, link_password)
+    for _ in range(50):
+        if "beta" in server_a.links and "alpha" in server_b.links:
+            break
+        await asyncio.sleep(0.05)
+    assert "beta" in server_a.links
+
+    # Kill server B to trigger retry on A
+    await server_b.stop()
+
+    # Wait for retry to be scheduled on A
+    for _ in range(50):
+        if "beta" in server_a._link_retry_state:
+            break
+        await asyncio.sleep(0.05)
+    assert "beta" in server_a._link_retry_state
+
+    # Restart server B and have it connect inbound to A
+    server_b2 = IRCd(config_b)
+    await server_b2.start()
+    server_b2.config.port = server_b2._server.sockets[0].getsockname()[1]
+    # Update A's link config so retry would point at the new B port
+    config_a.links[0].port = server_b2.config.port
+
+    # B2 connects to A (inbound connection to A)
+    await server_b2.connect_to_peer("127.0.0.1", server_a.config.port, link_password)
+    for _ in range(50):
+        if "beta" in server_a.links:
+            break
+        await asyncio.sleep(0.05)
+
+    assert "beta" in server_a.links
+    # Retry state should be cleared by the incoming connection
+    assert "beta" not in server_a._link_retry_state
+
+    # Cleanup
+    await server_a.stop()
+    await server_b2.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_after_initial_failure():
+    """If initial connect_to_peer fails, server schedules retry."""
+    link_password = TEST_LINK_PASSWORD
+    config_a = ServerConfig(
+        name="alpha",
+        host="127.0.0.1",
+        port=0,
+        links=[LinkConfig(name="beta", host="127.0.0.1", port=16999, password=link_password)],
+    )
+
+    server_a = IRCd(config_a)
+    await server_a.start()
+    server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+
+    # Simulate initial connection failure (port 16999 has nothing listening)
+    for lc in config_a.links:
+        try:
+            await server_a.connect_to_peer(lc.host, lc.port, lc.password, lc.trust)
+        except Exception:
+            server_a.maybe_retry_link(lc.name)
+
+    # Retry should be scheduled
+    assert "beta" in server_a._link_retry_state
+
+    # Clean up
+    server_a._link_retry_state["beta"]["task"].cancel()
+    await server_a.stop()

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,155 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mention_sends_notice(server, make_client):
+    """@mention in channel sends NOTICE to mentioned user."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :@testserv-claude hello")
+    lines = await client2.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    # Should get PRIVMSG relay AND server NOTICE
+    assert "PRIVMSG" in joined
+    assert "NOTICE" in joined
+    assert "mentioned you" in joined
+
+
+@pytest.mark.asyncio
+async def test_self_mention_ignored(server, make_client):
+    """Self-mention does not trigger a notification."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :@testserv-ori talking to myself")
+    lines1 = await client1.recv_all(timeout=1.0)
+    # ori should NOT get a mention NOTICE (self-mention)
+    joined = " ".join(lines1)
+    assert "mentioned you" not in joined
+
+
+@pytest.mark.asyncio
+async def test_unknown_nick_ignored(server, make_client):
+    """Mentioning a nick that doesn't exist is silently ignored."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :@testserv-nobody hello")
+    lines = await client1.recv_all(timeout=0.5)
+    # No error, no crash
+    joined = " ".join(lines)
+    assert "mentioned you" not in joined
+
+
+@pytest.mark.asyncio
+async def test_mentioned_user_not_in_channel_ignored(server, make_client):
+    """Mentioning a user not in the channel doesn't send NOTICE."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    # claude does NOT join #general
+
+    await client1.send("PRIVMSG #general :@testserv-claude hello")
+    lines = await client2.recv_all(timeout=0.5)
+    joined = " ".join(lines)
+    assert "mentioned you" not in joined
+
+
+@pytest.mark.asyncio
+async def test_multiple_mentions(server, make_client):
+    """Multiple @mentions in one message notify each user once."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    client3 = await make_client(nick="testserv-bob", user="bob")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client3.send("JOIN #general")
+    await client3.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :hey @testserv-claude and @testserv-bob check this")
+    lines2 = await client2.recv_all(timeout=1.0)
+    lines3 = await client3.recv_all(timeout=1.0)
+    assert any("mentioned you" in l for l in lines2)
+    assert any("mentioned you" in l for l in lines3)
+
+
+@pytest.mark.asyncio
+async def test_trailing_punctuation_stripped(server, make_client):
+    """Trailing punctuation on @nick is stripped for lookup."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :hello @testserv-claude, how are you?")
+    lines = await client2.recv_all(timeout=1.0)
+    assert any("mentioned you" in l for l in lines)
+
+
+@pytest.mark.asyncio
+async def test_mention_in_dm(server, make_client):
+    """Mention in a DM sends NOTICE to mentioned user."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await make_client(nick="testserv-claude", user="claude")
+    client3 = await make_client(nick="testserv-bob", user="bob")
+
+    await client1.send("PRIVMSG testserv-claude :tell @testserv-bob hi")
+    # bob should get the mention notice
+    lines3 = await client3.recv_all(timeout=1.0)
+    assert any("mentioned you" in l for l in lines3)
+
+
+@pytest.mark.asyncio
+async def test_privmsg_not_altered(server, make_client):
+    """PRIVMSG is relayed unchanged — mention only adds a NOTICE."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :@testserv-claude hello")
+    lines = await client2.recv_all(timeout=1.0)
+    privmsg_lines = [l for l in lines if "PRIVMSG" in l]
+    notice_lines = [l for l in lines if "NOTICE" in l]
+    assert len(privmsg_lines) == 1
+    assert "@testserv-claude hello" in privmsg_lines[0]
+    assert len(notice_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_mention_only_notifies_once(server, make_client):
+    """Same nick mentioned twice only sends one NOTICE."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :@testserv-claude @testserv-claude hello")
+    lines = await client2.recv_all(timeout=1.0)
+    notice_lines = [l for l in lines if "mentioned you" in l]
+    assert len(notice_lines) == 1

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,0 +1,103 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_privmsg_to_channel(server, make_client):
+    """PRIVMSG to a channel is relayed to other members."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    # Drain client1's notification of client2 joining
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :Hello agents!")
+    response = await client2.recv()
+    assert "PRIVMSG" in response
+    assert "#general" in response
+    assert "Hello agents!" in response
+    assert "testserv-ori" in response
+
+
+@pytest.mark.asyncio
+async def test_privmsg_not_echoed_to_sender(server, make_client):
+    """Sender does not receive their own PRIVMSG."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("PRIVMSG #general :talking to myself")
+    lines = await client1.recv_all(timeout=0.5)
+    privmsg_lines = [l for l in lines if "PRIVMSG" in l]
+    assert len(privmsg_lines) == 0
+
+
+@pytest.mark.asyncio
+async def test_privmsg_dm(server, make_client):
+    """PRIVMSG to a nick sends a DM."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("PRIVMSG testserv-claude :hey, need your help")
+    response = await client2.recv()
+    assert "PRIVMSG" in response
+    assert "testserv-claude" in response
+    assert "hey, need your help" in response
+
+
+@pytest.mark.asyncio
+async def test_privmsg_to_nonexistent_nick(server, make_client):
+    """PRIVMSG to unknown nick returns ERR_NOSUCHNICK."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("PRIVMSG testserv-nobody :hello?")
+    response = await client.recv()
+    assert "401" in response  # ERR_NOSUCHNICK
+
+
+@pytest.mark.asyncio
+async def test_privmsg_to_nonexistent_channel(server, make_client):
+    """PRIVMSG to unknown channel returns ERR_NOSUCHCHANNEL."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("PRIVMSG #doesnotexist :hello?")
+    response = await client.recv()
+    assert "403" in response  # ERR_NOSUCHCHANNEL
+
+
+@pytest.mark.asyncio
+async def test_notice_to_channel(server, make_client):
+    """NOTICE to a channel is relayed but generates no error replies."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("NOTICE #general :FYI check the benchmark results")
+    response = await client2.recv()
+    assert "NOTICE" in response
+    assert "FYI check the benchmark results" in response
+
+
+@pytest.mark.asyncio
+async def test_notice_to_nonexistent_channel_no_error(server, make_client):
+    """NOTICE to unknown channel produces no error (per RFC)."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("NOTICE #doesnotexist :hello")
+    lines = await client.recv_all(timeout=0.5)
+    assert len(lines) == 0
+
+
+@pytest.mark.asyncio
+async def test_notice_dm(server, make_client):
+    """NOTICE to a nick sends a DM."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("NOTICE testserv-claude :ping")
+    response = await client2.recv()
+    assert "NOTICE" in response
+    assert "ping" in response

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,327 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_first_joiner_gets_op(server, make_client):
+    """First user to join an empty channel gets @prefix in NAMES."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    lines = await client.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-ori" in names_line
+
+
+@pytest.mark.asyncio
+async def test_second_joiner_no_prefix(server, make_client):
+    """Second user to join does not get op."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    lines = await client2.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    # ori has @, claude has no prefix
+    assert "@testserv-ori" in names_line
+    assert "@testserv-claude" not in names_line
+    assert "testserv-claude" in names_line
+
+
+@pytest.mark.asyncio
+async def test_op_can_grant_op(server, make_client):
+    """Channel operator can grant +o to another user."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)  # drain join notification
+
+    await client1.send("MODE #general +o testserv-claude")
+    lines1 = await client1.recv_all(timeout=1.0)
+    lines2 = await client2.recv_all(timeout=1.0)
+
+    # Both users should see the MODE change
+    mode_line1 = " ".join(lines1)
+    mode_line2 = " ".join(lines2)
+    assert "MODE" in mode_line1
+    assert "+o" in mode_line1
+    assert "MODE" in mode_line2
+    assert "+o" in mode_line2
+
+    # Verify NAMES now shows @ for both
+    await client1.send("NAMES #general")
+    lines = await client1.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-ori" in names_line
+    assert "@testserv-claude" in names_line
+
+
+@pytest.mark.asyncio
+async def test_op_can_revoke_op(server, make_client):
+    """Channel operator can revoke -o from another user."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    # Grant then revoke
+    await client1.send("MODE #general +o testserv-claude")
+    await client1.recv_all(timeout=0.5)
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("MODE #general -o testserv-claude")
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("NAMES #general")
+    lines = await client1.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-ori" in names_line
+    assert "@testserv-claude" not in names_line
+
+
+@pytest.mark.asyncio
+async def test_op_can_grant_voice(server, make_client):
+    """Channel operator can grant +v."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("MODE #general +v testserv-claude")
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("NAMES #general")
+    lines = await client1.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "+testserv-claude" in names_line
+
+
+@pytest.mark.asyncio
+async def test_non_op_cannot_set_mode(server, make_client):
+    """Non-operator gets 482 error when trying to set modes."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client2.send("MODE #general +o testserv-claude")
+    lines = await client2.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "482" in joined
+
+
+@pytest.mark.asyncio
+async def test_mode_broadcast_to_all(server, make_client):
+    """MODE changes are broadcast to all channel members."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    client3 = await make_client(nick="testserv-bob", user="bob")
+    await client3.send("JOIN #general")
+    await client3.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("MODE #general +v testserv-claude")
+    lines3 = await client3.recv_all(timeout=1.0)
+    joined = " ".join(lines3)
+    assert "MODE" in joined
+    assert "+v" in joined
+
+
+@pytest.mark.asyncio
+async def test_mode_query_returns_324(server, make_client):
+    """MODE #channel query returns RPL_CHANNELMODEIS (324)."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("JOIN #general")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("MODE #general")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "324" in joined
+
+
+@pytest.mark.asyncio
+async def test_mode_nonexistent_channel(server, make_client):
+    """MODE on nonexistent channel returns 403."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE #doesnotexist")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "403" in joined
+
+
+@pytest.mark.asyncio
+async def test_mode_target_not_in_channel(server, make_client):
+    """MODE on a nick not in the channel returns 441."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("MODE #general +o testserv-claude")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "441" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_query(server, make_client):
+    """MODE <nick> returns RPL_UMODEIS (221)."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+
+
+@pytest.mark.asyncio
+async def test_part_removes_from_modes(server, make_client):
+    """PARTing a channel removes mode flags."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+
+    client2 = await make_client(nick="testserv-claude", user="claude")
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("MODE #general +o testserv-claude")
+    await client1.recv_all(timeout=0.5)
+    await client2.recv_all(timeout=0.5)
+
+    # Part and rejoin
+    await client2.send("PART #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("NAMES #general")
+    lines = await client1.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    # claude should not have @ after rejoin
+    assert "@testserv-claude" not in names_line
+
+
+@pytest.mark.asyncio
+async def test_multi_mode_different_targets(server, make_client):
+    """MODE #chan +ov nick1 nick2 grants op to nick1 and voice to nick2."""
+    op = await make_client(nick="testserv-ori", user="ori")
+    await op.send("JOIN #general")
+    await op.recv_all(timeout=0.5)
+
+    nick1 = await make_client(nick="testserv-alice", user="alice")
+    await nick1.send("JOIN #general")
+    await nick1.recv_all(timeout=0.5)
+    await op.recv_all(timeout=0.5)
+
+    nick2 = await make_client(nick="testserv-bob", user="bob")
+    await nick2.send("JOIN #general")
+    await nick2.recv_all(timeout=0.5)
+    await op.recv_all(timeout=0.5)
+    await nick1.recv_all(timeout=0.5)
+
+    await op.send("MODE #general +ov testserv-alice testserv-bob")
+    await op.recv_all(timeout=0.5)
+
+    await op.send("NAMES #general")
+    lines = await op.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-alice" in names_line
+    assert "+testserv-bob" in names_line
+
+
+@pytest.mark.asyncio
+async def test_multi_mode_insufficient_params(server, make_client):
+    """MODE #chan +ov nick1 applies +o to nick1, skips +v (no param)."""
+    op = await make_client(nick="testserv-ori", user="ori")
+    await op.send("JOIN #general")
+    await op.recv_all(timeout=0.5)
+
+    nick1 = await make_client(nick="testserv-alice", user="alice")
+    await nick1.send("JOIN #general")
+    await nick1.recv_all(timeout=0.5)
+    await op.recv_all(timeout=0.5)
+
+    await op.send("MODE #general +ov testserv-alice")
+    await op.recv_all(timeout=0.5)
+
+    await op.send("NAMES #general")
+    lines = await op.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    # alice got op but not voice (no second param)
+    assert "@testserv-alice" in names_line
+    assert "+testserv-alice" not in names_line
+
+
+@pytest.mark.asyncio
+async def test_last_op_leaves_autopromotes(server, make_client):
+    """When the last operator PARTs, a remaining member is auto-promoted."""
+    op = await make_client(nick="testserv-ori", user="ori")
+    await op.send("JOIN #general")
+    await op.recv_all(timeout=0.5)
+
+    member = await make_client(nick="testserv-claude", user="claude")
+    await member.send("JOIN #general")
+    await member.recv_all(timeout=0.5)
+    await op.recv_all(timeout=0.5)
+
+    # Op leaves
+    await op.send("PART #general")
+    await op.recv_all(timeout=0.5)
+    await member.recv_all(timeout=0.5)
+
+    # Remaining member should now be op
+    await member.send("NAMES #general")
+    lines = await member.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-claude" in names_line
+
+
+@pytest.mark.asyncio
+async def test_revoke_last_op_autopromotes(server, make_client):
+    """-o on the last op auto-promotes another member."""
+    op = await make_client(nick="testserv-ori", user="ori")
+    await op.send("JOIN #general")
+    await op.recv_all(timeout=0.5)
+
+    member = await make_client(nick="testserv-claude", user="claude")
+    await member.send("JOIN #general")
+    await member.recv_all(timeout=0.5)
+    await op.recv_all(timeout=0.5)
+
+    # Op revokes own op
+    await op.send("MODE #general -o testserv-ori")
+    await op.recv_all(timeout=0.5)
+    await member.recv_all(timeout=0.5)
+
+    # claude should be auto-promoted
+    await member.send("NAMES #general")
+    lines = await member.recv_all(timeout=1.0)
+    names_line = [l for l in lines if "353" in l][0]
+    assert "@testserv-claude" in names_line

--- a/tests/test_room_persistence.py
+++ b/tests/test_room_persistence.py
@@ -1,0 +1,75 @@
+"""Tests for room persistence (disk serialization)."""
+
+import os
+import tempfile
+
+import pytest
+
+
+def test_room_store_save_and_load():
+    """Rooms can be saved to disk and loaded back."""
+    from agentirc.channel import Channel
+    from agentirc.room_store import RoomStore
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = RoomStore(tmpdir)
+
+        ch = Channel("#pyhelp")
+        ch.room_id = "R7K2M9"
+        ch.creator = "spark-ori"
+        ch.owner = "spark-ori"
+        ch.purpose = "Python help"
+        ch.instructions = "Be helpful; share examples"
+        ch.tags = ["python", "code-help"]
+        ch.persistent = True
+        ch.agent_limit = 8
+        ch.extra_meta = {"language": "python"}
+        ch.created_at = 1774852147.0
+
+        store.save(ch)
+
+        assert os.path.exists(os.path.join(tmpdir, "rooms", "R7K2M9.json"))
+
+        loaded = store.load_all()
+        assert len(loaded) == 1
+        r = loaded[0]
+        assert r["room_id"] == "R7K2M9"
+        assert r["name"] == "#pyhelp"
+        assert r["creator"] == "spark-ori"
+        assert r["owner"] == "spark-ori"
+        assert r["purpose"] == "Python help"
+        assert r["instructions"] == "Be helpful; share examples"
+        assert r["tags"] == ["python", "code-help"]
+        assert r["persistent"] is True
+        assert r["agent_limit"] == 8
+        assert r["extra_meta"] == {"language": "python"}
+        assert r["created_at"] == pytest.approx(1774852147.0)
+
+
+def test_room_store_delete():
+    """Rooms can be deleted from store."""
+    from agentirc.channel import Channel
+    from agentirc.room_store import RoomStore
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = RoomStore(tmpdir)
+
+        ch = Channel("#pyhelp")
+        ch.room_id = "R7K2M9"
+        ch.persistent = True
+        ch.created_at = 1774852147.0
+        store.save(ch)
+
+        assert os.path.exists(os.path.join(tmpdir, "rooms", "R7K2M9.json"))
+
+        store.delete("R7K2M9")
+        assert not os.path.exists(os.path.join(tmpdir, "rooms", "R7K2M9.json"))
+
+
+def test_room_store_load_empty_dir():
+    """Loading from empty dir returns empty list."""
+    from agentirc.room_store import RoomStore
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = RoomStore(tmpdir)
+        assert store.load_all() == []

--- a/tests/test_rooms_federation.py
+++ b/tests/test_rooms_federation.py
@@ -1,0 +1,63 @@
+"""Tests for rooms federation (S2S sync)."""
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_sroommeta_syncs_on_burst(linked_servers, make_client_a):
+    """When a managed room exists, its metadata syncs to peers via burst."""
+    server_a, server_b = linked_servers
+
+    alice = await make_client_a(nick="alpha-alice", user="alice")
+    await alice.send("ROOMCREATE #shared :purpose=Shared room;tags=python;persistent=true")
+    await alice.recv_all(timeout=1.0)
+
+    # Set +S to share with beta
+    await alice.send("MODE #shared +S beta")
+    await alice.recv_all(timeout=1.0)
+
+    await asyncio.sleep(0.3)
+
+    # Server B should have the room metadata
+    channel_b = server_b.channels.get("#shared")
+    assert channel_b is not None
+    assert channel_b.room_id is not None
+    assert channel_b.purpose == "Shared room"
+    assert channel_b.tags == ["python"]
+
+
+@pytest.mark.asyncio
+async def test_stags_syncs_agent_tags(linked_servers, make_client_a):
+    """Agent tags sync via STAGS to federated peers."""
+    server_a, server_b = linked_servers
+
+    alice = await make_client_a(nick="alpha-alice", user="alice")
+    await alice.send("TAGS alpha-alice python,devops")
+    await alice.recv_all(timeout=1.0)
+
+    await asyncio.sleep(0.3)
+
+    rc = server_b.remote_clients.get("alpha-alice")
+    assert rc is not None
+    assert rc.tags == ["python", "devops"]
+
+
+@pytest.mark.asyncio
+async def test_sroomarchive_propagates(linked_servers, make_client_a):
+    """ROOMARCHIVE propagates to federated peers."""
+    server_a, server_b = linked_servers
+
+    alice = await make_client_a(nick="alpha-alice", user="alice")
+    await alice.send("ROOMCREATE #shared :purpose=Test;persistent=true")
+    await alice.recv_all(timeout=1.0)
+    await alice.send("MODE #shared +S beta")
+    await alice.recv_all(timeout=1.0)
+    await asyncio.sleep(0.3)
+
+    await alice.send("ROOMARCHIVE #shared")
+    await alice.recv_all(timeout=1.0)
+    await asyncio.sleep(0.3)
+
+    assert "#shared" not in server_b.channels
+    assert "#shared-archived" in server_b.channels
+    assert server_b.channels["#shared-archived"].archived is True

--- a/tests/test_rooms_federation.py
+++ b/tests/test_rooms_federation.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_sroommeta_syncs_on_burst(linked_servers, make_client_a):
     """When a managed room exists, its metadata syncs to peers via burst."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     alice = await make_client_a(nick="alpha-alice", user="alice")
     await alice.send("ROOMCREATE #shared :purpose=Shared room;tags=python;persistent=true")
@@ -29,7 +29,7 @@ async def test_sroommeta_syncs_on_burst(linked_servers, make_client_a):
 @pytest.mark.asyncio
 async def test_stags_syncs_agent_tags(linked_servers, make_client_a):
     """Agent tags sync via STAGS to federated peers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     alice = await make_client_a(nick="alpha-alice", user="alice")
     await alice.send("TAGS alpha-alice python,devops")
@@ -45,7 +45,7 @@ async def test_stags_syncs_agent_tags(linked_servers, make_client_a):
 @pytest.mark.asyncio
 async def test_sroomarchive_propagates(linked_servers, make_client_a):
     """ROOMARCHIVE propagates to federated peers."""
-    server_a, server_b = linked_servers
+    server_a, server_b = linked_servers  # NOSONAR S1481
 
     alice = await make_client_a(nick="alpha-alice", user="alice")
     await alice.send("ROOMCREATE #shared :purpose=Test;persistent=true")

--- a/tests/test_rooms_integration.py
+++ b/tests/test_rooms_integration.py
@@ -1,0 +1,110 @@
+"""End-to-end integration test for rooms management."""
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_full_room_lifecycle(server, make_client):
+    """Full lifecycle: create, set tags, invite, join, metadata, archive."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    # 1. Bob sets tags
+    await bob.send("TAGS testserv-bob python,devops")
+    await bob.recv_all(timeout=0.5)
+
+    # 2. Alice creates a managed room with python tag
+    await alice.send(
+        "ROOMCREATE #pyhelp :purpose=Python help;tags=python;persistent=true"
+        ";instructions=Help with Python questions"
+    )
+    await alice.recv_all(timeout=1.0)
+
+    # 3. Bob should have received a ROOMINVITE (tag match)
+    await asyncio.sleep(0.1)
+    lines = await bob.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "ROOMINVITE" in joined
+    assert "#pyhelp" in joined
+
+    # 4. Bob joins
+    await bob.send("JOIN #pyhelp")
+    await bob.recv_all(timeout=1.0)
+    await alice.recv_all(timeout=0.3)
+
+    # 5. Query metadata
+    await bob.send("ROOMMETA #pyhelp")
+    lines = await bob.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "Python help" in joined
+    assert "python" in joined
+
+    # 6. Query room ID
+    await bob.send("ROOMMETA #pyhelp room_id")
+    lines = await bob.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "R" in joined
+
+    # 7. Alice explicitly invites charlie
+    charlie = await make_client(nick="testserv-charlie", user="charlie")
+    await alice.send("ROOMINVITE #pyhelp testserv-charlie")
+    await alice.recv_all(timeout=0.5)
+    lines = await charlie.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "ROOMINVITE" in joined
+    assert "testserv-alice" in joined  # requestor
+
+    # 8. Alice archives the room
+    await alice.send("ROOMARCHIVE #pyhelp")
+    await alice.recv_all(timeout=1.0)
+    await bob.recv_all(timeout=1.0)
+
+    assert "#pyhelp" not in server.channels
+    assert "#pyhelp-archived" in server.channels
+    assert server.channels["#pyhelp-archived"].archived is True
+
+    # 9. Name is free — create a new room
+    await alice.send("ROOMCREATE #pyhelp :purpose=Python help v2")
+    await alice.recv_all(timeout=1.0)
+    assert "#pyhelp" in server.channels
+    assert server.channels["#pyhelp"].purpose == "Python help v2"
+
+
+@pytest.mark.asyncio
+async def test_persistent_room_survives_empty(server, make_client):
+    """Persistent managed room stays when all members leave."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+
+    await alice.send("ROOMCREATE #persistent :purpose=Stays;persistent=true")
+    await alice.recv_all(timeout=1.0)
+
+    room_id = server.channels["#persistent"].room_id
+
+    await alice.send("PART #persistent")
+    await alice.recv_all(timeout=1.0)
+
+    # Room still exists
+    assert "#persistent" in server.channels
+    assert server.channels["#persistent"].room_id == room_id
+
+    # Can rejoin
+    await alice.send("JOIN #persistent")
+    lines = await alice.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "JOIN" in joined
+    assert "#persistent" in joined
+
+
+@pytest.mark.asyncio
+async def test_non_persistent_room_cleaned_up(server, make_client):
+    """Non-persistent managed room is cleaned up when empty."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+
+    await alice.send("ROOMCREATE #temp :purpose=Temporary;persistent=false")
+    await alice.recv_all(timeout=1.0)
+
+    await alice.send("PART #temp")
+    await alice.recv_all(timeout=1.0)
+
+    assert "#temp" not in server.channels

--- a/tests/test_server_icon_skill.py
+++ b/tests/test_server_icon_skill.py
@@ -1,0 +1,214 @@
+"""Tests for server-side user modes (+H/+A/+B) and the ICON skill."""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# User mode tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_mode_set_h(server, make_client):
+    """MODE <nick> +H sets the Human mode flag and is returned in RPL_UMODEIS."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori +H")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+    assert "+H" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_set_a(server, make_client):
+    """MODE <nick> +A sets the Admin flag."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori +A")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+    assert "+A" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_set_b(server, make_client):
+    """MODE <nick> +B sets the Bot flag."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori +B")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+    assert "+B" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_multiple_flags(server, make_client):
+    """MODE <nick> +HA sets both Human and Admin flags."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori +HA")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+    # Both flags should appear in the mode string
+    assert "A" in joined
+    assert "H" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_unset(server, make_client):
+    """MODE <nick> -H removes the Human mode flag."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori +H")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("MODE testserv-ori -H")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+    # After removing, mode string should just be "+"
+    assert "+H" not in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_other_user_fails(server, make_client):
+    """Attempting to change another user's modes returns ERR_USERSDONTMATCH (502)."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    await make_client(nick="testserv-claude", user="claude")
+
+    await client1.send("MODE testserv-claude +H")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "502" in joined
+
+
+@pytest.mark.asyncio
+async def test_user_mode_query_no_modes(server, make_client):
+    """MODE <nick> with no modes set returns '+' in RPL_UMODEIS."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("MODE testserv-ori")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "221" in joined
+
+
+# ---------------------------------------------------------------------------
+# ICON skill tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_icon_set(server, make_client):
+    """ICON <value> sets the client's display icon."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("ICON 🧑")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "ICON" in joined
+    assert "🧑" in joined
+
+
+@pytest.mark.asyncio
+async def test_icon_query(server, make_client):
+    """ICON with no params returns current icon."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("ICON 🤖")
+    await client.recv_all(timeout=0.5)
+
+    await client.send("ICON")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "ICON" in joined
+    assert "🤖" in joined
+
+
+@pytest.mark.asyncio
+async def test_icon_query_none(server, make_client):
+    """ICON with no params and no icon set returns '(none)'."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("ICON")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "ICON" in joined
+    assert "(none)" in joined
+
+
+@pytest.mark.asyncio
+async def test_icon_too_long(server, make_client):
+    """ICON value longer than 4 chars returns an error NOTICE."""
+    client = await make_client(nick="testserv-ori", user="ori")
+    await client.send("ICON toolong")
+    lines = await client.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "NOTICE" in joined
+    assert "too long" in joined.lower()
+
+
+# ---------------------------------------------------------------------------
+# WHO response includes mode and icon info
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_who_includes_user_modes(server, make_client):
+    """WHO #channel reply includes user mode flags in the flags field."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+
+    await client2.send("MODE testserv-claude +H")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("WHO #general")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    # The WHO reply for claude should include [H] in the flags field
+    assert "[H]" in joined
+
+
+@pytest.mark.asyncio
+async def test_who_includes_icon(server, make_client):
+    """WHO #channel reply includes icon in the flags field."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+
+    await client2.send("ICON 🤖")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("WHO #general")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "{🤖}" in joined
+
+
+@pytest.mark.asyncio
+async def test_who_includes_mode_and_icon(server, make_client):
+    """WHO reply includes both modes and icon when both are set."""
+    client1 = await make_client(nick="testserv-ori", user="ori")
+    client2 = await make_client(nick="testserv-claude", user="claude")
+
+    await client2.send("MODE testserv-claude +B")
+    await client2.recv_all(timeout=0.5)
+    await client2.send("ICON 🤖")
+    await client2.recv_all(timeout=0.5)
+
+    await client1.send("JOIN #general")
+    await client1.recv_all(timeout=0.5)
+    await client2.send("JOIN #general")
+    await client2.recv_all(timeout=0.5)
+    await client1.recv_all(timeout=0.5)
+
+    await client1.send("WHO #general")
+    lines = await client1.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "[B]" in joined
+    assert "{🤖}" in joined

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,212 @@
+# tests/test_skills.py
+import asyncio
+
+import pytest
+
+from agentirc.skill import Event, EventType, Skill
+
+
+class RecorderSkill(Skill):
+    """Records all events for test assertions."""
+
+    name = "recorder"
+
+    def __init__(self):
+        self.events: list[Event] = []
+
+    async def on_event(self, event: Event) -> None:
+        self.events.append(event)
+
+
+class EchoSkill(Skill):
+    """Echoes back a NOTICE for any ECHO command."""
+
+    name = "echo"
+    commands = {"ECHO"}
+
+    async def on_command(self, client, msg):
+        from agentirc._internal.protocol.message import Message
+
+        text = msg.params[0] if msg.params else ""
+        await client.send(
+            Message(prefix=self.server.config.name, command="NOTICE", params=[client.nick, text])
+        )
+
+
+@pytest.mark.asyncio
+async def test_skill_receives_message_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("PRIVMSG #test :hello world")
+    await bob.recv()  # get the message
+    await asyncio.sleep(0.05)
+
+    # Filter to the specific message alice sent (system bots may also emit
+    # MESSAGE events for welcome messages when users join).
+    msg_events = [
+        e
+        for e in skill.events
+        if e.type == EventType.MESSAGE and e.nick == "testserv-alice" and e.channel == "#test"
+    ]
+    assert len(msg_events) == 1
+    assert msg_events[0].data["text"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_skill_receives_join_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+
+    join_events = [e for e in skill.events if e.type == EventType.JOIN]
+    assert len(join_events) == 1
+    assert join_events[0].channel == "#test"
+    assert join_events[0].nick == "testserv-alice"
+
+
+@pytest.mark.asyncio
+async def test_skill_receives_part_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+
+    await alice.send("PART #test :goodbye")
+    await alice.recv_all()
+
+    part_events = [e for e in skill.events if e.type == EventType.PART]
+    assert len(part_events) == 1
+    assert part_events[0].channel == "#test"
+    assert part_events[0].nick == "testserv-alice"
+    assert part_events[0].data["reason"] == "goodbye"
+
+
+@pytest.mark.asyncio
+async def test_skill_receives_quit_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+    await bob.send("JOIN #test")
+    await bob.recv_all()
+    await alice.recv_all()
+
+    await alice.send("QUIT :leaving now")
+    await asyncio.sleep(0.1)
+
+    quit_events = [e for e in skill.events if e.type == EventType.QUIT]
+    assert len(quit_events) == 1
+    assert quit_events[0].nick == "testserv-alice"
+    assert quit_events[0].data["reason"] == "leaving now"
+    assert "#test" in quit_events[0].data["channels"]
+
+
+@pytest.mark.asyncio
+async def test_skill_receives_topic_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+
+    await alice.send("TOPIC #test :new topic")
+    await alice.recv_all()
+
+    topic_events = [e for e in skill.events if e.type == EventType.TOPIC]
+    assert len(topic_events) == 1
+    assert topic_events[0].channel == "#test"
+    assert topic_events[0].nick == "testserv-alice"
+    assert topic_events[0].data["topic"] == "new topic"
+
+
+@pytest.mark.asyncio
+async def test_multiple_skills_receive_events(server, make_client):
+    skill1 = RecorderSkill()
+    skill2 = RecorderSkill()
+    await server.register_skill(skill1)
+    await server.register_skill(skill2)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #test")
+    await alice.recv_all()
+
+    join_events_1 = [e for e in skill1.events if e.type == EventType.JOIN]
+    join_events_2 = [e for e in skill2.events if e.type == EventType.JOIN]
+    assert len(join_events_1) == 1
+    assert len(join_events_2) == 1
+
+
+@pytest.mark.asyncio
+async def test_dm_message_event(server, make_client):
+    skill = RecorderSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("PRIVMSG testserv-bob :hello dm")
+    await bob.recv()
+    await asyncio.sleep(0.05)
+
+    msg_events = [e for e in skill.events if e.type == EventType.MESSAGE]
+    assert len(msg_events) == 1
+    assert msg_events[0].channel is None
+    assert msg_events[0].nick == "testserv-alice"
+    assert msg_events[0].data["text"] == "hello dm"
+
+
+# --- Command dispatch tests ---
+
+
+@pytest.mark.asyncio
+async def test_skill_handles_unknown_command(server, make_client):
+    skill = EchoSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("ECHO :hello skill")
+    resp = await alice.recv()
+    assert "NOTICE" in resp
+    assert "hello skill" in resp
+
+
+@pytest.mark.asyncio
+async def test_unhandled_command_still_errors(server, make_client):
+    skill = EchoSkill()
+    await server.register_skill(skill)
+
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("FAKECMD test")
+    resp = await alice.recv()
+    assert "421" in resp  # ERR_UNKNOWNCOMMAND
+
+
+@pytest.mark.asyncio
+async def test_skill_command_requires_registration(server, make_client):
+    skill = EchoSkill()
+    await server.register_skill(skill)
+
+    # Create unregistered client (no nick/user)
+    client = await make_client()
+    await client.send("ECHO :should not work")
+    # Unregistered client should not get a response from the skill
+    lines = await client.recv_all(timeout=0.5)
+    assert not any("hello" in line.lower() for line in lines)

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,384 @@
+"""Tests for ThreadsSkill — CREATE, REPLY, THREADS list, THREADCLOSE, PROMOTE."""
+
+import asyncio
+import tempfile
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_thread_create_delivers_prefixed_privmsg(server, make_client):
+    """THREAD CREATE should deliver a [thread:name] prefixed PRIVMSG to channel members."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)  # drain bob's join
+
+    await alice.send("THREAD CREATE #general auth-refactor :Let's refactor auth")
+    response = await bob.recv(timeout=2.0)
+    assert "PRIVMSG" in response
+    assert "#general" in response
+    assert "[thread:auth-refactor]" in response
+    assert "Let's refactor auth" in response
+
+
+@pytest.mark.asyncio
+async def test_thread_create_duplicate_name_errors(server, make_client):
+    """Creating a thread with a name that already exists should return an error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general my-thread :first message")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general my-thread :duplicate")
+    response = await alice.recv(timeout=2.0)
+    assert "400" in response or "already exists" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_thread_create_not_on_channel_errors(server, make_client):
+    """THREAD CREATE on a channel you haven't joined should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #nochannel my-thread :hello")
+    response = await alice.recv(timeout=2.0)
+    assert "442" in response
+
+
+@pytest.mark.asyncio
+async def test_thread_create_invalid_name_errors(server, make_client):
+    """THREAD CREATE with an invalid thread name should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general --bad-name :hello")
+    response = await alice.recv(timeout=2.0)
+    assert "400" in response or "invalid" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_delivers_prefixed_privmsg(server, make_client):
+    """THREAD REPLY should deliver a [thread:name] prefixed PRIVMSG."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general my-thread :first message")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await bob.send("THREAD REPLY #general my-thread :second message")
+    response = await alice.recv(timeout=2.0)
+    assert "PRIVMSG" in response
+    assert "#general" in response
+    assert "[thread:my-thread]" in response
+    assert "second message" in response
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_nonexistent_thread_errors(server, make_client):
+    """THREAD REPLY to a thread that doesn't exist should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD REPLY #general no-thread :hello")
+    response = await alice.recv(timeout=2.0)
+    assert "404" in response or "no such thread" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_threads_list(server, make_client):
+    """THREADS should list active threads in a channel."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general thread-a :first")
+    await alice.recv_all(timeout=0.5)
+    await alice.send("THREAD CREATE #general thread-b :second")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREADS #general")
+    lines = await alice.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "thread-a" in joined
+    assert "thread-b" in joined
+    assert "THREADSEND" in joined
+
+
+@pytest.mark.asyncio
+async def test_threadclose_archives_thread(server, make_client):
+    """THREADCLOSE should archive a thread and post summary notice."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general my-thread :hello")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREADCLOSE #general my-thread :Done discussing")
+    lines = await alice.recv_all(timeout=1.0)
+    joined = " ".join(lines)
+    assert "NOTICE" in joined
+    assert "my-thread" in joined
+
+    # Reply to closed thread should fail
+    await alice.send("THREAD REPLY #general my-thread :too late")
+    response = await alice.recv(timeout=2.0)
+    assert "405" in response or "closed" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_threadclose_unauthorized_errors(server, make_client):
+    """THREADCLOSE by a non-participant non-operator should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general my-thread :hello")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    # Bob didn't participate in the thread and isn't channel operator
+    await bob.send("THREADCLOSE #general my-thread :closing")
+    response = await bob.recv(timeout=2.0)
+    assert "482" in response or "not authorized" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_threadclose_promote_creates_breakout(server, make_client):
+    """THREADCLOSE PROMOTE should create a breakout channel and auto-join participants."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    bob = await make_client(nick="testserv-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general auth-refactor :Let's refactor auth")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+
+    await bob.send("THREAD REPLY #general auth-refactor :Good idea")
+    await alice.recv_all(timeout=0.5)
+    await bob.recv_all(timeout=0.5)
+
+    await alice.send("THREADCLOSE PROMOTE #general auth-refactor")
+    await asyncio.sleep(0.3)
+    alice_lines = await alice.recv_all(timeout=1.0)
+    bob_lines = await bob.recv_all(timeout=1.0)
+
+    alice_joined = " ".join(alice_lines)
+    bob_joined = " ".join(bob_lines)
+
+    # Both should get JOIN for breakout channel
+    assert "JOIN" in alice_joined
+    assert "#general-auth-refactor" in alice_joined
+    assert "JOIN" in bob_joined
+    assert "#general-auth-refactor" in bob_joined
+
+    # Breakout channel should exist on server
+    assert "#general-auth-refactor" in server.channels
+
+    # History replay as NOTICE
+    assert "NOTICE" in alice_joined or "NOTICE" in bob_joined
+
+
+@pytest.mark.asyncio
+async def test_thread_create_missing_params_errors(server, make_client):
+    """THREAD CREATE with missing parameters should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general")
+    response = await alice.recv(timeout=2.0)
+    assert "461" in response or "not enough" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_thread_unknown_subcommand_errors(server, make_client):
+    """THREAD with an unknown subcommand should error."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("THREAD BADCMD #general foo :bar")
+    response = await alice.recv(timeout=2.0)
+    assert "NOTICE" in response or "unknown" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_to_archived_thread_errors(server, make_client):
+    """Replying to a closed thread should return 405."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general done-thread :starting")
+    await alice.recv_all(timeout=0.5)
+    await alice.send("THREADCLOSE #general done-thread :all done")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD REPLY #general done-thread :too late")
+    response = await alice.recv(timeout=2.0)
+    assert "405" in response
+
+
+@pytest.mark.asyncio
+async def test_threadclose_archived_thread_not_listed(server, make_client):
+    """Closed threads should not appear in THREADS listing."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general temp-thread :temporary")
+    await alice.recv_all(timeout=0.5)
+    await alice.send("THREADCLOSE #general temp-thread :done")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREADS #general")
+    lines = await alice.recv_all(timeout=1.0)
+    thread_lines = [l for l in lines if "THREADS" in l and "THREADSEND" not in l]
+    assert len(thread_lines) == 0
+
+
+@pytest.mark.asyncio
+async def test_threadclose_promote_replays_history(server, make_client):
+    """Promoted breakout should receive thread history as NOTICEs."""
+    alice = await make_client(nick="testserv-alice", user="alice")
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREAD CREATE #general replay-test :Message one")
+    await alice.recv_all(timeout=0.5)
+    await alice.send("THREAD REPLY #general replay-test :Message two")
+    await alice.recv_all(timeout=0.5)
+
+    await alice.send("THREADCLOSE PROMOTE #general replay-test")
+    lines = await alice.recv_all(timeout=2.0)
+
+    # Should see history replay as NOTICEs in the breakout
+    notices = [l for l in lines if "NOTICE" in l and "#general-replay-test" in l]
+    assert len(notices) >= 2
+    assert any("Message one" in n for n in notices)
+    assert any("Message two" in n for n in notices)
+
+
+@pytest.mark.asyncio
+async def test_threads_persist_across_restart():
+    """Threads should survive server restart when data_dir is configured."""
+    from agentirc.config import ServerConfig
+    from agentirc.ircd import IRCd
+    from tests.conftest import IRCTestClient
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        config = ServerConfig(name="testserv", host="127.0.0.1", port=0, data_dir=data_dir)
+
+        # Start server, create a thread
+        ircd = IRCd(config)
+        await ircd.start()
+        port = ircd._server.sockets[0].getsockname()[1]
+        ircd.config.port = port
+
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        alice = IRCTestClient(reader, writer)
+        await alice.send("NICK testserv-alice")
+        await alice.send("USER alice 0 * :alice")
+        await alice.recv_all(timeout=0.5)
+        await alice.send("JOIN #general")
+        await alice.recv_all(timeout=0.5)
+        await alice.send("THREAD CREATE #general persist-test :Hello")
+        await alice.recv_all(timeout=0.5)
+
+        await alice.close()
+        await ircd.stop()
+
+        # Restart server
+        ircd2 = IRCd(config)
+        await ircd2.start()
+        port2 = ircd2._server.sockets[0].getsockname()[1]
+        ircd2.config.port = port2
+
+        reader2, writer2 = await asyncio.open_connection("127.0.0.1", port2)
+        bob = IRCTestClient(reader2, writer2)
+        await bob.send("NICK testserv-bob")
+        await bob.send("USER bob 0 * :bob")
+        await bob.recv_all(timeout=0.5)
+        await bob.send("JOIN #general")
+        await bob.recv_all(timeout=0.5)
+
+        # Thread should still exist
+        await bob.send("THREADS #general")
+        lines = await bob.recv_all(timeout=1.0)
+        thread_lines = [l for l in lines if "THREADS" in l and "THREADSEND" not in l]
+        assert any("persist-test" in l for l in thread_lines)
+
+        await bob.close()
+        await ircd2.stop()
+
+
+@pytest.mark.asyncio
+async def test_thread_create_federates(linked_servers, make_client_a, make_client_b):
+    """THREAD CREATE on server A should deliver prefixed PRIVMSG to server B."""
+    alice = await make_client_a(nick="alpha-alice", user="alice")
+    bob = await make_client_b(nick="beta-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)  # federation settle
+
+    await alice.send("THREAD CREATE #general fed-thread :Cross-server thread")
+    response = await bob.recv(timeout=3.0)
+    assert "PRIVMSG" in response
+    assert "[thread:fed-thread]" in response
+    assert "Cross-server thread" in response
+
+
+@pytest.mark.asyncio
+async def test_thread_close_federates(linked_servers, make_client_a, make_client_b):
+    """THREADCLOSE on server A should deliver summary NOTICE to server B."""
+    alice = await make_client_a(nick="alpha-alice", user="alice")
+    bob = await make_client_b(nick="beta-bob", user="bob")
+
+    await alice.send("JOIN #general")
+    await alice.recv_all(timeout=0.5)
+    await bob.send("JOIN #general")
+    await bob.recv_all(timeout=0.5)
+    await alice.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    await alice.send("THREAD CREATE #general fed-close :Starting")
+    await bob.recv(timeout=3.0)
+
+    await alice.send("THREADCLOSE #general fed-close :All done")
+    response = await bob.recv(timeout=3.0)
+    assert "NOTICE" in response
+    assert "Thread fed-close closed" in response or "fed-close" in response

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,11 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version < '3.12'",
 ]
 
 [[package]]
@@ -53,21 +52,9 @@ provides-extras = ["dev"]
 name = "astroid"
 version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -96,16 +83,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
-    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
     { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
     { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
     { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
@@ -134,7 +114,6 @@ name = "citation-cli"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomli-w" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/fa/caa57183d370b88531ea50918a55592ec8d89ac22f5d8429b8198a7e4df9/citation_cli-0.1.0.tar.gz", hash = "sha256:0629c8ea2e1733162f34b66f9ca539c5cf8ac0e6acbf04a5d8e4fd7031ff07a0", size = 6417, upload-time = "2026-04-14T00:22:44.51Z" }
@@ -170,18 +149,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -228,16 +195,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/cd/bb7b7e54084a344c03d68144450da7ddd5564e51a298ae1662de65f48e2d/grpcio-1.80.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:886457a7768e408cdce226ad1ca67d2958917d306523a0e21e1a2fdaa75c9c9c", size = 6050363, upload-time = "2026-03-30T08:46:20.894Z" },
-    { url = "https://files.pythonhosted.org/packages/16/02/1417f5c3460dea65f7a2e3c14e8b31e77f7ffb730e9bfadd89eda7a9f477/grpcio-1.80.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7b641fc3f1dc647bfd80bd713addc68f6d145956f64677e56d9ebafc0bd72388", size = 12026037, upload-time = "2026-03-30T08:46:25.144Z" },
-    { url = "https://files.pythonhosted.org/packages/43/98/c910254eedf2cae368d78336a2de0678e66a7317d27c02522392f949b5c6/grpcio-1.80.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33eb763f18f006dc7fee1e69831d38d23f5eccd15b2e0f92a13ee1d9242e5e02", size = 6602306, upload-time = "2026-03-30T08:46:27.593Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f8/88ca4e78c077b2b2113d95da1e1ab43efd43d723c9a0397d26529c2c1a56/grpcio-1.80.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:52d143637e3872633fc7dd7c3c6a1c84e396b359f3a72e215f8bf69fd82084fc", size = 7301535, upload-time = "2026-03-30T08:46:29.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/96/f28660fe2fe0f153288bf4a04e4910b7309d442395135c88ed4f5b3b8b40/grpcio-1.80.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c51bf8ac4575af2e0678bccfb07e47321fc7acb5049b4482832c5c195e04e13a", size = 6808669, upload-time = "2026-03-30T08:46:31.984Z" },
-    { url = "https://files.pythonhosted.org/packages/47/eb/3f68a5e955779c00aeef23850e019c1c1d0e032d90633ba49c01ad5a96e0/grpcio-1.80.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:50a9871536d71c4fba24ee856abc03a87764570f0c457dd8db0b4018f379fed9", size = 7409489, upload-time = "2026-03-30T08:46:34.684Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/a7/d2f681a4bfb881be40659a309771f3bdfbfdb1190619442816c3f0ffc079/grpcio-1.80.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a72d84ad0514db063e21887fbacd1fd7acb4d494a564cae22227cd45c7fbf199", size = 8423167, upload-time = "2026-03-30T08:46:36.833Z" },
-    { url = "https://files.pythonhosted.org/packages/97/8a/29b4589c204959aa35ce5708400a05bba72181807c45c47b3ec000c39333/grpcio-1.80.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7691a6788ad9196872f95716df5bc643ebba13c97140b7a5ee5c8e75d1dea81", size = 7846761, upload-time = "2026-03-30T08:46:40.091Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d2/ed143e097230ee121ac5848f6ff14372dba91289b10b536d54fb1b7cbae7/grpcio-1.80.0-cp310-cp310-win32.whl", hash = "sha256:46c2390b59d67f84e882694d489f5b45707c657832d7934859ceb8c33f467069", size = 4156534, upload-time = "2026-03-30T08:46:42.026Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c9/df8279bb49b29409995e95efa85b72973d62f8aeff89abee58c91f393710/grpcio-1.80.0-cp310-cp310-win_amd64.whl", hash = "sha256:dc053420fc75749c961e2a4c906398d7c15725d36ccc04ae6d16093167223b58", size = 4889869, upload-time = "2026-03-30T08:46:44.219Z" },
     { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
     { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
     { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
@@ -520,7 +477,6 @@ dependencies = [
     { name = "isort" },
     { name = "mccabe" },
     { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomlkit" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
@@ -534,12 +490,10 @@ version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -551,7 +505,6 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -579,11 +532,6 @@ version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
     { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
     { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
     { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
@@ -618,15 +566,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
     { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
     { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
     { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
@@ -696,60 +635,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
-    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
-    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
-    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
-    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
-    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentirc-cli"
-version = "9.2.0"
+version = "9.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
## Summary

- Migrate the bootstrap test suite from `culture@df50942`: 21 server-core + 15 telemetry tests (~6.5kloc) plus 2 helper modules (`_fakes.py`, `_metrics_helpers.py`).
- Adapt `tests/conftest.py` (paraphrase): drop dead `_BOTS_DIR_*` patches and the `server_with_bot` / `server_with_bots` fixtures that have no agentirc analogue. Keep `IRCTestClient`, the IRCd lifecycle fixtures, and the telemetry/audit fixtures.
- Bump `9.2.0 → 9.3.0`. **315 tests run under `pytest -n auto` in ~29s.**

## What landed

| Category | Count | LOC | Citation status |
|---|---|---|---|
| `tests/conftest.py` | 1 | 312 | `paraphrase` |
| `tests/test_*.py` (root) | 21 | ~5,170 | `quote` × 20, `paraphrase` × 1 (`test_events_basic.py`) |
| `tests/telemetry/test_*.py` | 15 | ~1,615 | `quote` × 14, `paraphrase` × 1 (`test_tracing.py`) |
| `tests/telemetry/_fakes.py` + `_metrics_helpers.py` | 2 | — | `quote` |

Three new `[tool.citation.packages.*]` blocks: `culture-tests-conftest`, `culture-tests-server-core`, `culture-tests-telemetry`.

## Two paraphrase deviations beyond pure import rewrites

- `tests/test_events_basic.py`: dead `with patch("culture.bots.*.BOTS_DIR", …)` block removed (no-op against agentirc's no-op `_internal/bots/` stubs — same dead-weight rationale as the conftest patches).
- `tests/telemetry/test_tracing.py`: one `unittest.mock.patch` target rewritten from `"culture.telemetry.tracing.OTLPSpanExporter"` to `"agentirc._internal.telemetry.tracing.OTLPSpanExporter"`. This is a functional patch (mocks out the OTLP gRPC exporter), not a sandbox no-op.

Observability-identifier strings preserved verbatim — they are public surface downstream consumers grep for:
- OTEL service name `"culture.agentirc"`
- Metric keys `"culture.s2s.messages"`, `"culture.s2s.links_active"`, `"culture.s2s.relay_latency"`, `"culture.s2s.link_events"`
- Span attributes `"culture.federation.peer"`, `"culture.trace.origin"`, `"culture.trace.dropped_reason"`
- Audit tag `"culture.dev/traceparent"`

## One agentirc-side fix

`agentirc/server_link.py:_replay_event` parameter renamed back from `_seq` (PR-B1's unused-arg compliance variant) to `seq` to match the upstream signature culture's `tests/test_federation.py::test_replay_event_handles_string_typed_message_event` assumes via keyword-arg call. Signature carries `# noqa: ARG002` to keep the linter quiet.

## Out of scope (stay in culture)

- `tests/telemetry/test_bot_event_dispatch_span.py`, `test_bot_run_span.py`, `test_metrics_bots.py` (need real `BotManager` for the bot-event path)
- `test_welcome_bot.py` (inspects `bot_manager.bots` internals — agentirc's stub doesn't have it)
- `tests/telemetry/conftest.py` (only consumer is the deferred bot tests above)
- 57-file bucket-C surface (`culture.{cli,console,daemon,clients,credentials,mesh_config}`)

## Bootstrap remaining

- **PR-B4** — `docs/api-stability.md`, `docs/cli.md`, `docs/deployment.md`. Pure prose; not gating culture's cutover.

## Test plan

- [x] `pytest -n auto` green (315 / 315 in ~29s)
- [x] `git grep -nE '^(from|import) culture\b' agentirc/ tests/` → zero matches (hard invariant)
- [x] `cite check` → all packages green
- [x] Public API smoke: `from agentirc.{config,cli,protocol}` all import on a clean session
- [x] `agentirc --version` → `9.3.0`
- [x] `.claude/skills/pr-review/scripts/workflow.sh lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude