### PR TITLE
feat(protocol): public Event/EventType + verb/CAP exports for 9.5.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- Public `agentirc.protocol` exports for the bot extension API: the `Event` dataclass, the `EventType` enum (now `StrEnum`), 20 per-type `EVENT_TYPE_*` string constants, the `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` / `EVENTPUB` verb constants, and the `BOT_CAP = "agentirc.io/bot"` capability identifier. `Event.type` is widened to `EventType | str` so federation peers can deliver event types this version doesn't recognise. See `docs/superpowers/specs/2026-05-01-bot-extension-api-design.md` for the full design and `docs/extension-api.md` for the bot-author quick reference.
-- `ServerConfig.event_subscription_queue_max: int = 1024` — per-subscription queue bound. Recognised by `ServerConfig.from_yaml` as a top-level key. Consumed by the subscription registry that lands in 9.5.0a3.
+- Public `agentirc.protocol` exports for the bot extension API: the `Event` dataclass, the `EventType` enum, 20 per-type `EVENT_TYPE_*` string constants, the `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` / `EVENTPUB` verb constants, and the `BOT_CAP = "agentirc.io/bot"` capability identifier. `Event.type` is widened to `EventType | str` so federation peers can deliver event types this version doesn't recognise. See `docs/superpowers/specs/2026-05-01-bot-extension-api-design.md` for the full design and `docs/extension-api.md` for the bot-author quick reference.
+- `ServerConfig.event_subscription_queue_max: int = 1024` — per-subscription queue bound. Recognised by `ServerConfig.from_yaml` and `cli._resolve_config()` as a top-level YAML key. Consumed by the subscription registry that lands in 9.5.0a3.
 - `agentirc.skill` keeps re-exporting `Event` and `EventType` for backward compat; the re-export shim is removed in 9.6.0 once Phase A2 confirms no consumer relies on the path.
+
+### Changed
+
+- `EventType` upgraded from `enum.Enum` to `enum.StrEnum`. Members keep their `.value` strings unchanged, but Python consumers now observe new identity semantics: `isinstance(EventType.JOIN, str)` is `True`, `EventType.JOIN == "user.join"` is `True`, JSON serialization emits the bare string. Internal call sites verified — none compare `EventType.X` against a bare string today, so the truthier equality is pure improvement; downstream consumers that did string-equality round-trips against `EventType` see strictly more matches, never fewer.
 
 ### Notes
 
-- This is the **declarations slice** of the bot extension API. No behavior changes: `EVENTSUB` etc. are reserved verb constants but the daemon does not yet handle them; `BOT_CAP` is exported but not yet advertised in `CAP LS` output. The wire-format envelope refactor lands in 9.5.0a2; the bot CAP behavior, subscription verbs, `EVENTPUB`, and `webhook_port` unbinding land in 9.5.0a3 / 9.5.0 final.
+- This is the **declarations slice** of the bot extension API. No daemon-level behavior changes: `EVENTSUB` etc. are reserved verb constants but the daemon does not yet handle them; `BOT_CAP` is exported but not yet advertised in `CAP LS` output. The wire-format envelope refactor lands in 9.5.0a2; the bot CAP behavior, subscription verbs, `EVENTPUB`, and `webhook_port` unbinding land in 9.5.0a3 / 9.5.0 final.
 - Tracks [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15).
 
 ## [9.4.1] - 2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [9.5.0a1] - 2026-05-02
+
+### Added
+
+- Public `agentirc.protocol` exports for the bot extension API: the `Event` dataclass, the `EventType` enum (now `StrEnum`), 20 per-type `EVENT_TYPE_*` string constants, the `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` / `EVENTPUB` verb constants, and the `BOT_CAP = "agentirc.io/bot"` capability identifier. `Event.type` is widened to `EventType | str` so federation peers can deliver event types this version doesn't recognise. See `docs/superpowers/specs/2026-05-01-bot-extension-api-design.md` for the full design and `docs/extension-api.md` for the bot-author quick reference.
+- `ServerConfig.event_subscription_queue_max: int = 1024` — per-subscription queue bound. Recognised by `ServerConfig.from_yaml` as a top-level key. Consumed by the subscription registry that lands in 9.5.0a3.
+- `agentirc.skill` keeps re-exporting `Event` and `EventType` for backward compat; the re-export shim is removed in 9.6.0 once Phase A2 confirms no consumer relies on the path.
+
+### Notes
+
+- This is the **declarations slice** of the bot extension API. No behavior changes: `EVENTSUB` etc. are reserved verb constants but the daemon does not yet handle them; `BOT_CAP` is exported but not yet advertised in `CAP LS` output. The wire-format envelope refactor lands in 9.5.0a2; the bot CAP behavior, subscription verbs, `EVENTPUB`, and `webhook_port` unbinding land in 9.5.0a3 / 9.5.0 final.
+- Tracks [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15).
+
 ## [9.4.1] - 2026-05-01
 
 ### Documentation

--- a/agentirc/cli.py
+++ b/agentirc/cli.py
@@ -185,6 +185,9 @@ def _resolve_config(args: argparse.Namespace) -> "ServerConfig":  # noqa: F821 (
             args.data_dir, raw.get("data_dir"), os.path.expanduser("~/.culture/data")
         )
     )
+    event_subscription_queue_max = _pick(
+        None, raw.get("event_subscription_queue_max"), 1024
+    )
 
     cfg = ServerConfig(
         name=name or "agentirc",
@@ -195,6 +198,7 @@ def _resolve_config(args: argparse.Namespace) -> "ServerConfig":  # noqa: F821 (
         links=_resolve_links(getattr(args, "link", None), raw.get("links") or []),
         system_bots=raw.get("system_bots") or {},
         telemetry=_build_telemetry(raw.get("telemetry") or {}),
+        event_subscription_queue_max=event_subscription_queue_max,
     )
 
     args.name = name  # may be None — handler resolves via default-server file

--- a/agentirc/config.py
+++ b/agentirc/config.py
@@ -65,7 +65,9 @@ class ServerConfig:
         """Load a ServerConfig from a YAML file.
 
         Recognises top-level ``server`` (host/port/name), ``telemetry``,
-        ``links``, ``webhook_port``, ``data_dir``, and ``system_bots``.
+        ``links``, ``webhook_port``, ``data_dir``, ``system_bots``, and
+        ``event_subscription_queue_max`` (added in 9.5.0a1; consumed by
+        the subscription registry that lands in 9.5.0a3).
         Unknown top-level keys (``supervisor``, ``agents``, ``buffer_size``,
         ``poll_interval``, ``sleep_start``, ``sleep_end``) are silently
         ignored — those belong to culture's broader process supervisor,

--- a/agentirc/config.py
+++ b/agentirc/config.py
@@ -53,6 +53,12 @@ class ServerConfig:
     links: list[LinkConfig] = field(default_factory=list)
     system_bots: dict = field(default_factory=dict)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+    # Bot extension API (9.5.0): per-subscription event-queue bound. When
+    # exceeded, the subscription is dropped with EVENTERR :backpressure-overflow
+    # and the bot reconciles via re-subscribe + BACKFILL. Behavior wires up in
+    # 9.5.0a3; the field is exposed in 9.5.0a1 so consumers can pin against the
+    # public surface.
+    event_subscription_queue_max: int = 1024
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "ServerConfig":
@@ -104,7 +110,7 @@ def _yaml_kwargs(raw: dict[str, Any]) -> dict[str, Any]:
     for key in ("name", "host", "port"):
         if key in server_section:
             kwargs[key] = server_section[key]
-    for key in ("webhook_port", "data_dir"):
+    for key in ("webhook_port", "data_dir", "event_subscription_queue_max"):
         if key in raw:
             kwargs[key] = raw[key]
     links_section = raw.get("links") or []

--- a/agentirc/protocol.py
+++ b/agentirc/protocol.py
@@ -31,6 +31,11 @@ clients and federation. They need a coordinated cross-repo bump.
 
 from __future__ import annotations
 
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
 # ---------------------------------------------------------------------------
 # Numeric reply codes (re-exported from the internal module)
 # ---------------------------------------------------------------------------
@@ -164,6 +169,90 @@ ROOMETAEND = "ROOMETAEND"  # SIC: typo preserved for wire compat (ROOMMETAEND ta
 ROOMETASET = "ROOMETASET"  # SIC: typo preserved for wire compat (ROOMMETASET target)
 
 
+# ---------------------------------------------------------------------------
+# Bot extension API (9.5.0)
+# ---------------------------------------------------------------------------
+# Public Event dataclass + EventType enum, per-type string constants, the
+# EVENTSUB / EVENTUNSUB / EVENT / EVENTERR / EVENTPUB verb names, and the
+# bot-CAP token. See docs/superpowers/specs/2026-05-01-bot-extension-api-design.md
+# for the wire format and verb syntax. Behavior wiring lands in 9.5.0a2/a3;
+# 9.5.0a1 ships these symbols only.
+
+# `EventType` is `StrEnum` so `EventType.JOIN == "user.join"` is True at JSON
+# boundaries. Adding a new member is a minor bump; renaming or removing one
+# is a major bump.
+
+
+class EventType(StrEnum):
+    MESSAGE = "message"
+    JOIN = "user.join"
+    PART = "user.part"
+    QUIT = "user.quit"
+    TOPIC = "topic"
+    ROOMMETA = "room.meta"
+    TAGS = "tags.update"
+    ROOMARCHIVE = "room.archive"
+    THREAD_CREATE = "thread.create"
+    THREAD_MESSAGE = "thread.message"
+    THREAD_CLOSE = "thread.close"
+    AGENT_CONNECT = "agent.connect"
+    AGENT_DISCONNECT = "agent.disconnect"
+    CONSOLE_OPEN = "console.open"
+    CONSOLE_CLOSE = "console.close"
+    SERVER_WAKE = "server.wake"
+    SERVER_SLEEP = "server.sleep"
+    SERVER_LINK = "server.link"
+    SERVER_UNLINK = "server.unlink"
+    ROOM_CREATE = "room.create"
+
+
+@dataclass
+class Event:
+    # `type` is widened to `EventType | str` so federation peers can deliver
+    # event types this version doesn't recognise without raising. Subscribers
+    # must tolerate unknown types (forward-compat).
+    type: EventType | str
+    channel: str | None
+    nick: str
+    data: dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+
+# Per-type string constants — parallel to `EventType` for callers that prefer
+# bare strings (e.g. comparing JSON-decoded `type` field without enum-coercing).
+EVENT_TYPE_MESSAGE = "message"
+EVENT_TYPE_USER_JOIN = "user.join"
+EVENT_TYPE_USER_PART = "user.part"
+EVENT_TYPE_USER_QUIT = "user.quit"
+EVENT_TYPE_TOPIC = "topic"
+EVENT_TYPE_ROOM_META = "room.meta"
+EVENT_TYPE_TAGS_UPDATE = "tags.update"
+EVENT_TYPE_ROOM_ARCHIVE = "room.archive"
+EVENT_TYPE_THREAD_CREATE = "thread.create"
+EVENT_TYPE_THREAD_MESSAGE = "thread.message"
+EVENT_TYPE_THREAD_CLOSE = "thread.close"
+EVENT_TYPE_AGENT_CONNECT = "agent.connect"
+EVENT_TYPE_AGENT_DISCONNECT = "agent.disconnect"
+EVENT_TYPE_CONSOLE_OPEN = "console.open"
+EVENT_TYPE_CONSOLE_CLOSE = "console.close"
+EVENT_TYPE_SERVER_WAKE = "server.wake"
+EVENT_TYPE_SERVER_SLEEP = "server.sleep"
+EVENT_TYPE_SERVER_LINK = "server.link"
+EVENT_TYPE_SERVER_UNLINK = "server.unlink"
+EVENT_TYPE_ROOM_CREATE = "room.create"
+
+# Bot extension verbs.
+EVENTSUB = "EVENTSUB"
+EVENTUNSUB = "EVENTUNSUB"
+EVENT = "EVENT"
+EVENTERR = "EVENTERR"
+EVENTPUB = "EVENTPUB"
+
+# Bot-CAP token. Vendored namespace per IRCv3 conventions, prevents collision
+# with hypothetical bare-`bot` caps from non-agentirc IRC servers.
+BOT_CAP = "agentirc.io/bot"
+
+
 __all__ = [
     # Numerics
     "ERR_ALREADYREGISTRED",
@@ -256,4 +345,33 @@ __all__ = [
     "STAGS",
     "STHREAD",
     "STOPIC",
+    # Bot extension API (9.5.0)
+    "BOT_CAP",
+    "EVENT",
+    "EVENTERR",
+    "EVENTPUB",
+    "EVENTSUB",
+    "EVENTUNSUB",
+    "Event",
+    "EventType",
+    "EVENT_TYPE_AGENT_CONNECT",
+    "EVENT_TYPE_AGENT_DISCONNECT",
+    "EVENT_TYPE_CONSOLE_CLOSE",
+    "EVENT_TYPE_CONSOLE_OPEN",
+    "EVENT_TYPE_MESSAGE",
+    "EVENT_TYPE_ROOM_ARCHIVE",
+    "EVENT_TYPE_ROOM_CREATE",
+    "EVENT_TYPE_ROOM_META",
+    "EVENT_TYPE_SERVER_LINK",
+    "EVENT_TYPE_SERVER_SLEEP",
+    "EVENT_TYPE_SERVER_UNLINK",
+    "EVENT_TYPE_SERVER_WAKE",
+    "EVENT_TYPE_TAGS_UPDATE",
+    "EVENT_TYPE_THREAD_CLOSE",
+    "EVENT_TYPE_THREAD_CREATE",
+    "EVENT_TYPE_THREAD_MESSAGE",
+    "EVENT_TYPE_TOPIC",
+    "EVENT_TYPE_USER_JOIN",
+    "EVENT_TYPE_USER_PART",
+    "EVENT_TYPE_USER_QUIT",
 ]

--- a/agentirc/protocol.py
+++ b/agentirc/protocol.py
@@ -1,6 +1,6 @@
-"""Public protocol surface for agentirc — verbs, numerics, and tags.
+"""Public protocol surface for agentirc — verbs, numerics, tags, and the bot extension API.
 
-Semver-tracked module. Three categories of constants live here:
+Semver-tracked module. Five categories of public symbols live here:
 
 1. **Verb names** — IRC command verbs as bare uppercase tokens. Mostly
    RFC 2812 (PRIVMSG, JOIN, QUIT, ...), plus agentirc skill verbs
@@ -14,6 +14,16 @@ Semver-tracked module. Three categories of constants live here:
    consumers don't reach into the underscore namespace.
 3. **Message tag names** — IRCv3 tag keys for traceparent/tracestate
    and agentirc-specific event tags.
+4. **Event types and the Event dataclass** — :class:`EventType`
+   (a :class:`enum.StrEnum` of 20 dotted-lowercase wire strings) and
+   :class:`Event` (a frozen-shape dataclass). Plus 20 ``EVENT_TYPE_*``
+   per-type string constants for callers that prefer bare strings over
+   enum-coercion at JSON boundaries. Added in 9.5.0a1 as part of the
+   bot extension API.
+5. **Bot extension verbs and capability** — ``EVENTSUB``, ``EVENTUNSUB``,
+   ``EVENT``, ``EVENTERR``, ``EVENTPUB`` verb constants and
+   ``BOT_CAP = "agentirc.io/bot"``. Reserved in 9.5.0a1; daemon
+   behavior wires up in 9.5.0a3 / 9.5.0 final.
 
 Existing call sites under ``agentirc.ircd``, ``agentirc.server_link``
 and the skills modules still use inline string literals. Migrating them

--- a/agentirc/skill.py
+++ b/agentirc/skill.py
@@ -1,47 +1,20 @@
 from __future__ import annotations
 
-import time
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+# Event and EventType moved to agentirc.protocol in 9.5.0a1 as part of the
+# bot extension API public surface. This module keeps re-exporting them so
+# internal call sites and any pre-9.5 vendored consumers keep working; the
+# re-export is removed in 9.6.0 once Phase A2 confirms no consumer relies on
+# this path.
+from agentirc.protocol import Event, EventType
+
+__all__ = ["Event", "EventType", "Skill"]
 
 if TYPE_CHECKING:
     from agentirc.client import Client
     from agentirc.ircd import IRCd
     from agentirc._internal.protocol.message import Message
-
-
-class EventType(Enum):
-    MESSAGE = "message"
-    JOIN = "user.join"
-    PART = "user.part"
-    QUIT = "user.quit"
-    TOPIC = "topic"
-    ROOMMETA = "room.meta"
-    TAGS = "tags.update"
-    ROOMARCHIVE = "room.archive"
-    THREAD_CREATE = "thread.create"
-    THREAD_MESSAGE = "thread.message"
-    THREAD_CLOSE = "thread.close"
-    # Lifecycle + link events introduced by mesh-events feature.
-    AGENT_CONNECT = "agent.connect"
-    AGENT_DISCONNECT = "agent.disconnect"
-    CONSOLE_OPEN = "console.open"
-    CONSOLE_CLOSE = "console.close"
-    SERVER_WAKE = "server.wake"
-    SERVER_SLEEP = "server.sleep"
-    SERVER_LINK = "server.link"
-    SERVER_UNLINK = "server.unlink"
-    ROOM_CREATE = "room.create"
-
-
-@dataclass
-class Event:
-    type: EventType
-    channel: str | None
-    nick: str
-    data: dict[str, Any] = field(default_factory=dict)
-    timestamp: float = field(default_factory=time.time)
 
 
 class Skill:

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -12,13 +12,29 @@ import only from these three modules.
 | [`agentirc.cli`](#agentirccli) | `main()`, `dispatch(argv) -> int` | Public, semver-tracked |
 | [`agentirc.protocol`](#agentircprotocol) | Verb constants, numeric reply codes, IRCv3/extension tag names | Public, semver-tracked |
 
-> **Reserved for 9.5.0 (pending implementation):** `agentirc.protocol` will
-> additionally export the `Event` dataclass, the `EventType` enum,
-> per-type `EVENT_TYPE_*` string constants, the
-> `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verb constants, and the
-> `BOT_CAP = "agentirc.io/bot"` capability identifier. `ServerConfig`
-> will gain a new `event_subscription_queue_max: int = 1024` field. The
-> wire format and verb syntax are specified in
+> **Bot extension API — phased rollout:**
+>
+> - **9.5.0a1 (current alpha — declarations slice):** `agentirc.protocol`
+>   exports the `Event` dataclass, the `EventType` enum (now `StrEnum`),
+>   20 per-type `EVENT_TYPE_*` string constants, the
+>   `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verb constants,
+>   and the `BOT_CAP = "agentirc.io/bot"` capability identifier.
+>   `ServerConfig` gains the `event_subscription_queue_max: int = 1024`
+>   field. **The symbols are importable; the daemon does not yet handle
+>   the verbs and does not advertise `BOT_CAP`** — calling them is a
+>   no-op until the behavior slices land.
+> - **9.5.0a2 (planned):** wire-format envelope refactor —
+>   `_build_event_payload`/`_encode_event_data` emit the 5-field envelope
+>   `{type, channel, nick, data, timestamp}`; federated `SEVENT` shifts
+>   to the new shape. Internal change; no new public symbols.
+> - **9.5.0a3 (planned):** bot-CAP behavior, `EVENTSUB`/`EVENTUNSUB`
+>   handlers, the in-memory `SubscriptionRegistry`, and `EVENTPUB`
+>   handler. Daemon starts advertising `BOT_CAP` in `CAP LS` output.
+> - **9.5.0 (final):** `webhook_port` no longer bound; `cli.md` /
+>   `deployment.md` updated; this block flips from "phased rollout" to
+>   "current," and the version-history table picks up a 9.5.0 row.
+>
+> Wire format and verb syntax are specified in
 > [`docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`](superpowers/specs/2026-05-01-bot-extension-api-design.md);
 > a quick reference for bot authors is at [`docs/extension-api.md`](extension-api.md).
 > Tracking issue: [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentirc-cli"
-version = "9.4.1"
+version = "9.5.0a1"
 description = "Agent-friendly IRCd: server core for AI agent meshes"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_protocol_bot_exports.py
+++ b/tests/test_protocol_bot_exports.py
@@ -150,6 +150,33 @@ def test_server_config_yaml_loads_event_queue_max(tmp_path):
     assert cfg.event_subscription_queue_max == 256
 
 
+def test_cli_resolve_config_propagates_event_queue_max(tmp_path, monkeypatch):
+    """`agentirc serve --config ...` honors event_subscription_queue_max from YAML.
+
+    Regression guard for PR #17 review (Copilot 3176158134): the cli-level
+    config resolver previously dropped the field on the floor, so the dataclass
+    default leaked through even when YAML overrode it.
+    """
+    import argparse
+
+    from agentirc.cli import _resolve_config
+
+    yaml_path = tmp_path / "server.yaml"
+    yaml_path.write_text("event_subscription_queue_max: 42\n")
+
+    args = argparse.Namespace(
+        config=str(yaml_path),
+        name=None,
+        host=None,
+        port=None,
+        webhook_port=None,
+        data_dir=None,
+        link=None,
+    )
+    cfg = _resolve_config(args)
+    assert cfg.event_subscription_queue_max == 42
+
+
 def test_protocol_all_exports_new_symbols():
     """`__all__` lists the new bot-extension members so star-imports get them."""
     from agentirc import protocol

--- a/tests/test_protocol_bot_exports.py
+++ b/tests/test_protocol_bot_exports.py
@@ -1,0 +1,187 @@
+"""Tests for the public bot extension API surface (9.5.0a1).
+
+Behavior wires up in 9.5.0a2/a3; these tests only verify that the public
+symbols are importable from `agentirc.protocol`, that the type-string
+vocabulary is internally consistent (enum members ↔ per-type constants),
+and that `agentirc.skill` still re-exports `Event` / `EventType` so internal
+call sites keep working.
+
+When 9.5.0 final ships and the spec's "9.5.0-pending" block in
+`docs/api-stability.md` flips to "current," this file is the golden anchor
+for the public surface — adding a test here is the convention for asserting
+that a new symbol is part of the contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from enum import StrEnum
+
+import pytest
+
+
+def test_event_dataclass_importable_from_protocol():
+    from agentirc.protocol import Event
+
+    assert is_dataclass(Event)
+    e = Event(type="user.join", channel="#room", nick="alice")
+    assert e.type == "user.join"
+    assert e.channel == "#room"
+    assert e.nick == "alice"
+    assert e.data == {}
+    assert isinstance(e.timestamp, float)
+
+
+def test_event_type_is_strenum():
+    from agentirc.protocol import EventType
+
+    assert issubclass(EventType, StrEnum)
+    # StrEnum members compare equal to their string values — this is the whole
+    # point of using StrEnum at JSON boundaries.
+    assert EventType.JOIN == "user.join"
+    assert EventType.MESSAGE == "message"
+    assert EventType.ROOM_CREATE == "room.create"
+    # Member is a string instance.
+    assert isinstance(EventType.JOIN, str)
+
+
+def test_event_type_has_twenty_members():
+    from agentirc.protocol import EventType
+
+    assert len(list(EventType)) == 20
+
+
+@pytest.mark.parametrize(
+    "member_name,wire_value,constant_name",
+    [
+        ("MESSAGE", "message", "EVENT_TYPE_MESSAGE"),
+        ("JOIN", "user.join", "EVENT_TYPE_USER_JOIN"),
+        ("PART", "user.part", "EVENT_TYPE_USER_PART"),
+        ("QUIT", "user.quit", "EVENT_TYPE_USER_QUIT"),
+        ("TOPIC", "topic", "EVENT_TYPE_TOPIC"),
+        ("ROOMMETA", "room.meta", "EVENT_TYPE_ROOM_META"),
+        ("TAGS", "tags.update", "EVENT_TYPE_TAGS_UPDATE"),
+        ("ROOMARCHIVE", "room.archive", "EVENT_TYPE_ROOM_ARCHIVE"),
+        ("THREAD_CREATE", "thread.create", "EVENT_TYPE_THREAD_CREATE"),
+        ("THREAD_MESSAGE", "thread.message", "EVENT_TYPE_THREAD_MESSAGE"),
+        ("THREAD_CLOSE", "thread.close", "EVENT_TYPE_THREAD_CLOSE"),
+        ("AGENT_CONNECT", "agent.connect", "EVENT_TYPE_AGENT_CONNECT"),
+        ("AGENT_DISCONNECT", "agent.disconnect", "EVENT_TYPE_AGENT_DISCONNECT"),
+        ("CONSOLE_OPEN", "console.open", "EVENT_TYPE_CONSOLE_OPEN"),
+        ("CONSOLE_CLOSE", "console.close", "EVENT_TYPE_CONSOLE_CLOSE"),
+        ("SERVER_WAKE", "server.wake", "EVENT_TYPE_SERVER_WAKE"),
+        ("SERVER_SLEEP", "server.sleep", "EVENT_TYPE_SERVER_SLEEP"),
+        ("SERVER_LINK", "server.link", "EVENT_TYPE_SERVER_LINK"),
+        ("SERVER_UNLINK", "server.unlink", "EVENT_TYPE_SERVER_UNLINK"),
+        ("ROOM_CREATE", "room.create", "EVENT_TYPE_ROOM_CREATE"),
+    ],
+)
+def test_event_type_vocabulary_parity(member_name, wire_value, constant_name):
+    """Every EventType member has a matching EVENT_TYPE_* constant with the same wire value."""
+    from agentirc import protocol
+
+    member = getattr(protocol.EventType, member_name)
+    constant = getattr(protocol, constant_name)
+    assert member.value == wire_value
+    assert constant == wire_value
+    assert member == constant  # StrEnum makes this hold
+
+
+def test_bot_extension_verb_constants():
+    """The five new verb constants exist with their canonical wire values."""
+    from agentirc.protocol import EVENT, EVENTERR, EVENTPUB, EVENTSUB, EVENTUNSUB
+
+    assert EVENTSUB == "EVENTSUB"
+    assert EVENTUNSUB == "EVENTUNSUB"
+    assert EVENT == "EVENT"
+    assert EVENTERR == "EVENTERR"
+    assert EVENTPUB == "EVENTPUB"
+
+
+def test_bot_cap_token():
+    """The bot capability is the IRCv3 vendored-namespace token."""
+    from agentirc.protocol import BOT_CAP
+
+    assert BOT_CAP == "agentirc.io/bot"
+
+
+def test_skill_module_still_re_exports():
+    """`agentirc.skill` re-exports `Event` / `EventType` for backward compat.
+
+    Internal call sites (`agentirc/ircd.py`, `agentirc/skills/*`) and any
+    pre-9.5 vendored consumer that imports from `agentirc.skill` keep working.
+    The re-export shim is scheduled for removal in 9.6.0.
+    """
+    from agentirc.skill import Event as SkillEvent
+    from agentirc.skill import EventType as SkillEventType
+    from agentirc.protocol import Event as ProtoEvent
+    from agentirc.protocol import EventType as ProtoEventType
+
+    # `is` identity — re-export, not a copy.
+    assert SkillEvent is ProtoEvent
+    assert SkillEventType is ProtoEventType
+
+
+def test_event_tolerates_unknown_type_string():
+    """`Event.type` is widened to `EventType | str` for forward-compat."""
+    from agentirc.protocol import Event
+
+    # An unknown type from a federation peer running newer agentirc round-trips
+    # without raising. The type is the bare string; callers must tolerate it.
+    e = Event(type="some.future.event", channel=None, nick="")
+    assert e.type == "some.future.event"
+
+
+def test_server_config_event_queue_field():
+    """The new event_subscription_queue_max field is part of ServerConfig."""
+    from agentirc.config import ServerConfig
+
+    cfg = ServerConfig()
+    assert cfg.event_subscription_queue_max == 1024
+
+
+def test_server_config_yaml_loads_event_queue_max(tmp_path):
+    """ServerConfig.from_yaml recognises event_subscription_queue_max."""
+    from agentirc.config import ServerConfig
+
+    yaml_path = tmp_path / "server.yaml"
+    yaml_path.write_text("event_subscription_queue_max: 256\n")
+    cfg = ServerConfig.from_yaml(yaml_path)
+    assert cfg.event_subscription_queue_max == 256
+
+
+def test_protocol_all_exports_new_symbols():
+    """`__all__` lists the new bot-extension members so star-imports get them."""
+    from agentirc import protocol
+
+    expected_new = {
+        "BOT_CAP",
+        "Event",
+        "EventType",
+        "EVENT",
+        "EVENTERR",
+        "EVENTPUB",
+        "EVENTSUB",
+        "EVENTUNSUB",
+        "EVENT_TYPE_AGENT_CONNECT",
+        "EVENT_TYPE_AGENT_DISCONNECT",
+        "EVENT_TYPE_CONSOLE_CLOSE",
+        "EVENT_TYPE_CONSOLE_OPEN",
+        "EVENT_TYPE_MESSAGE",
+        "EVENT_TYPE_ROOM_ARCHIVE",
+        "EVENT_TYPE_ROOM_CREATE",
+        "EVENT_TYPE_ROOM_META",
+        "EVENT_TYPE_SERVER_LINK",
+        "EVENT_TYPE_SERVER_SLEEP",
+        "EVENT_TYPE_SERVER_UNLINK",
+        "EVENT_TYPE_SERVER_WAKE",
+        "EVENT_TYPE_TAGS_UPDATE",
+        "EVENT_TYPE_THREAD_CLOSE",
+        "EVENT_TYPE_THREAD_CREATE",
+        "EVENT_TYPE_THREAD_MESSAGE",
+        "EVENT_TYPE_TOPIC",
+        "EVENT_TYPE_USER_JOIN",
+        "EVENT_TYPE_USER_PART",
+        "EVENT_TYPE_USER_QUIT",
+    }
+    assert expected_new.issubset(set(protocol.__all__))

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentirc-cli"
-version = "9.4.1"
+version = "9.5.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
## Summary

Part **1 of 3** implementing PR-EXT-2 (issue [#15](https://github.com/agentculture/agentirc/issues/15)). **Declarations only — zero behavior change.** Following the slicing approved with the spec PR (#16) merged as `e0b323d`:

- **Part 1 — this PR — `9.5.0a1`:** public surface additions in `agentirc.protocol` and `agentirc.config`.
- **Part 2 — next — `9.5.0a2`:** wire-format envelope refactor (touches federation; standalone for focused review).
- **Part 3 — final — `9.5.0`:** bot-CAP behavior, `EVENTSUB`/`EVENTUNSUB`/`EVENTPUB` handlers, `webhook_port` unbinding. Closes #15.

This part lets culture (or any future bot consumer) `pip install agentirc-cli==9.5.0a1.devN` from TestPyPI and verify the public surface lines up with the spec, before any behavior risk lands.

## Public surface added

**`agentirc.protocol`:**
- `Event` dataclass (moved from `agentirc.skill`). `type` widened to `EventType | str` for forward-compat with federation peers delivering unknown types.
- `EventType` enum (moved from `agentirc.skill`). Upgraded `Enum` → `StrEnum` so `EventType.JOIN == \"user.join\"` holds at JSON boundaries. All 20 members keep their `.value` strings; internal call sites checked, none compare `EventType.X` against a bare string.
- 20 `EVENT_TYPE_*` per-type string constants (one per enum member).
- `EVENTSUB`, `EVENTUNSUB`, `EVENT`, `EVENTERR`, `EVENTPUB` verb constants.
- `BOT_CAP = \"agentirc.io/bot\"`.

**`agentirc.config.ServerConfig`:**
- `event_subscription_queue_max: int = 1024`. Recognised by `from_yaml` as a top-level key.

## Backward compatibility

`agentirc.skill` keeps re-exporting `Event` / `EventType` (now via `from agentirc.protocol import ...`). The 7+ internal call sites (`agentirc/ircd.py`, `agentirc/server_link.py`, `agentirc/client.py`, `agentirc/skills/*`) and any pre-9.5 vendored consumer keep working unchanged. The re-export shim is removed in 9.6.0 once Phase A2 confirms no consumer relies on the path.

## Test plan

- [x] 30 new tests in `tests/test_protocol_bot_exports.py`:
  - import smoke for every new symbol
  - `StrEnum` semantics (`EventType.JOIN == \"user.join\"`)
  - vocabulary parity (every enum member ↔ `EVENT_TYPE_*` constant, exactly 20 of each)
  - `BOT_CAP` value lock
  - `Event` tolerates unknown type strings
  - `agentirc.skill.{Event, EventType} is agentirc.protocol.{Event, EventType}` identity
  - `ServerConfig.event_subscription_queue_max` default + YAML wiring
  - `__all__` membership for every new public symbol
- [x] Full suite: **361 passed** (was 328 + 30 new + 3 I missed in prior count). `pytest -n auto` in 28s.
- [x] Public-API import smoke in a clean shell: `python -c \"from agentirc.protocol import Event, EventType, EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB, BOT_CAP; print('ok')\"` — succeeds.
- [x] `agentirc.skill` re-export still works: `from agentirc.skill import Event, EventType` returns the same classes as `agentirc.protocol`.
- [x] Portability lint clean (5 files checked).
- [x] `flake8 -F` clean on touched files.
- [ ] **TestPyPI install round-trip:** publish.yml will tag `9.5.0a1.devN` on push; verify `pip install -i …testpypi… agentirc-cli==9.5.0a1.devN` followed by the import smoke from above. (Will verify after first dev-publish run.)

## Out of scope (Parts 2 + 3)

- **Wire-format envelope** (`_build_event_payload`, `_encode_event_data`, `SEVENT` relay) — Part 2.
- **Bot-CAP behavior** (silent JOIN, no auto-op, NAMES `+` flag, WHO `B` flag) — Part 3.
- **`EVENTSUB` / `EVENTUNSUB` handlers + `SubscriptionRegistry`** — Part 3.
- **`EVENTPUB` handler** — Part 3.
- **`webhook_port` unbinding** — Part 3.
- **`docs/api-stability.md` flip** from `9.5.0-pending` to `9.5.0` — Part 3 (the surface is exported but inert until Part 3 wires the behavior).

## Spec references

- Design: [`docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`](https://github.com/agentculture/agentirc/blob/main/docs/superpowers/specs/2026-05-01-bot-extension-api-design.md)
- Bot-author quick reference: [`docs/extension-api.md`](https://github.com/agentculture/agentirc/blob/main/docs/extension-api.md)
- Public-API contract: [`docs/api-stability.md`](https://github.com/agentculture/agentirc/blob/main/docs/api-stability.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude