### PR TITLE
feat: bot CAP + EVENTSUB/EVENTUNSUB/EVENTPUB + webhook unbind (9.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [9.5.0] - 2026-05-02
+
+Closes [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15) — out-of-process bot extension API. Unblocks [agentculture/culture#308](https://github.com/agentculture/culture/issues/308) Phase A2 (bot rewrite against the public API).
+
+### Added
+
+- **IRCv3 `agentirc.io/bot` capability.** Advertised in `CAP LS` output. When negotiated via `CAP REQ`, gates four behaviours: silent JOIN/PART/QUIT broadcasts (other channel members see nothing), no auto-op on a fresh-channel first-joiner, `+` prefix in NAMES output, `B` flag in WHO output. Channel membership is added normally; events still fire (subscribers see them via `EVENTSUB`).
+- **`EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` IRC verbs** for streaming events to bots out-of-process. `EVENTSUB <sub-id> [type=<glob>] [channel=<name>] [nick=<glob>]`: filters AND-ed; `type` and `nick` accept `fnmatch`-style globs; `channel` accepts an exact name, `*`, or empty (nick-scoped only). Multiple concurrent subscriptions per client are allowed. Wire format: `:server EVENT <sub-id> <type> <channel-or-*> <nick> :<base64-json-envelope>` carrying the canonical 5-field envelope. Per-subscription bounded queue (default 1024); on overflow the server emits `EVENTERR <sub-id> :backpressure-overflow` and drops the subscription (connection stays open). Subscriptions die on client disconnect.
+- **`EVENTPUB` IRC verb** for bots to emit custom-typed events back into the stream. `EVENTPUB <type> <channel-or-*> :<base64-json-data>`. Type validated against `EVENT_TYPE_RE` (dotted lowercase, ≥1 dot — single-segment names like `message` and `topic` are reserved for built-in vocabulary). Server fills `nick` from the bot's connection nick (not spoofable) and `timestamp` from `time.time()` so federation peers see consistent clocks. `_`-prefixed keys are stripped from the payload before emit.
+- New internal module `agentirc._internal.event_subscriptions` with the `Subscription` dataclass and `SubscriptionRegistry`. `IRCd.subscription_registry` exposes the registry; `IRCd.emit_event` dispatches every event through it.
+- `agentirc.protocol.SEVENT` verb constant (added in 9.5.0a2; reaffirmed here).
+
+### Changed
+
+- **`webhook_port` is no longer bound by `IRCd.start()`.** The field stays in `ServerConfig` so culture's `~/.culture/server.yaml` keeps loading unchanged, but `agentirc` no longer instantiates the HTTP listener. Consumers that need webhook→bot dispatch host their own listener (see `docs/deployment.md`). No deprecation warning at runtime — the docs change is sufficient.
+- `Channel.add()` no longer auto-ops bot-CAP clients (real or `VirtualClient`). A bot joining an empty channel stays unprivileged; the next human becomes op.
+- `Channel.get_prefix()` returns `+` for bot-CAP members in NAMES output.
+- `Client._build_who_flags()` adds the `B` flag for bot-CAP members in WHO output (composes with `H` and `@`/`+`).
+- `VirtualClient` gains a class-level `caps = frozenset({"agentirc.io/bot", "message-tags"})` so the in-process system bot is treated identically to a real CAP-bot.
+- `Client._handle_cap` `CAP LS` reply now lists supported caps from a class-level `_SUPPORTED_CAPS` frozenset (centralised; removing a cap is a major bump).
+- `agentirc/_internal/bots/http_listener.py` module docstring notes the no-op stub is scheduled for removal in 9.6.0.
+
+### Notes
+
+- This is the **final slice** of the bot extension API. `9.5.0a1` shipped the public `agentirc.protocol` declarations; `9.5.0a2` switched the federation wire format to the 5-field envelope; this release wires the actual behaviour.
+- **Federation interop unchanged from 9.5.0a2.** 9.4→9.5 federation works (sniff tolerance); 9.5→9.4 emit breaks until peers upgrade.
+- The `agentirc.skill.{Event, EventType}` re-export shim from 9.5.0a1 stays through the 9.x line; removal is scheduled for 10.0.0.
+- The `agentirc/_internal/bots/` synthesize stubs (`bot_manager.py`, `http_listener.py`) stay through the 9.5.x cycle; removal is scheduled for 9.6.0 once Phase A2 confirms no consumer imports them.
+
 ## [9.5.0a2] - 2026-05-02
 
 ### Changed

--- a/agentirc/_internal/bots/http_listener.py
+++ b/agentirc/_internal/bots/http_listener.py
@@ -1,10 +1,18 @@
-"""No-op ``HttpListener`` stub.
+"""No-op ``HttpListener`` stub (scheduled for removal in 9.6.0).
 
 Pairs with the no-op :class:`agentirc._internal.bots.bot_manager.BotManager`.
 The real implementation lives in ``culture.bots.http_listener`` and exposes
 a webhook surface for triggering bot events. In a standalone agentirc
 deployment there is nothing to listen for, so ``start()`` and ``stop()``
 are no-ops.
+
+As of 9.5.0, :class:`agentirc.ircd.IRCd` no longer instantiates this stub —
+the webhook listener is the consumer's responsibility (see
+``docs/api-stability.md`` and ``docs/deployment.md``). The class itself
+stays in the codebase for one cycle so any vendored test or culture-runtime
+override that imports it keeps working; it is scheduled for deletion in
+9.6.0 once Phase A2 of agentculture/culture#308 confirms no consumer
+imports it.
 """
 
 from __future__ import annotations

--- a/agentirc/_internal/event_subscriptions.py
+++ b/agentirc/_internal/event_subscriptions.py
@@ -196,34 +196,35 @@ class SubscriptionRegistry:
 
         server_name = client.server.config.name
 
-        while True:
-            try:
+        try:
+            while True:
                 event = await sub.queue.get()
-            except asyncio.CancelledError:
-                return
+                if sub.dropped:
+                    return
 
-            if sub.dropped:
-                return
-
-            type_wire = str(event.type)
-            target = event.channel if event.channel is not None else "*"
-            envelope = IRCd._build_event_envelope(event)
-            encoded = IRCd._encode_event_data(envelope, type_wire)
-            line = (
-                f":{server_name} {EVENT} {sub.sub_id} {type_wire} "
-                f"{target} {event.nick} :{encoded}"
-            )
-            try:
-                await client.send_raw(line)
-            except Exception:
-                # Connection is gone or send failed; let the disconnect
-                # cleanup path remove this subscription.
-                logger.debug(
-                    "EVENT send to %s sub %s failed; awaiting disconnect cleanup",
-                    getattr(client, "nick", "<?>"),
-                    sub.sub_id,
+                type_wire = str(event.type)
+                target = event.channel if event.channel is not None else "*"
+                envelope = IRCd._build_event_envelope(event)
+                encoded = IRCd._encode_event_data(envelope, type_wire)
+                line = (
+                    f":{server_name} {EVENT} {sub.sub_id} {type_wire} "
+                    f"{target} {event.nick} :{encoded}"
                 )
-                return
+                try:
+                    await client.send_raw(line)
+                except Exception:
+                    # Connection is gone or send failed; let the disconnect
+                    # cleanup path remove this subscription.
+                    logger.debug(
+                        "EVENT send to %s sub %s failed; awaiting disconnect cleanup",
+                        getattr(client, "nick", "<?>"),
+                        sub.sub_id,
+                    )
+                    return
+        except asyncio.CancelledError:
+            # Drain task cancelled by ``remove`` or ``remove_client`` —
+            # propagate so asyncio cleanup runs as normal.
+            raise
 
 
 __all__ = [

--- a/agentirc/_internal/event_subscriptions.py
+++ b/agentirc/_internal/event_subscriptions.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import logging
+import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from agentirc.client import Client
@@ -45,6 +46,46 @@ CHANNEL_ANY = "*"
 # A per-subscription channel filter that matches only nick-scoped events
 # (events with ``event.channel is None``).
 CHANNEL_NICK_SCOPED_ONLY = ""
+
+# Channel-filter format for ``EVENTSUB``: an exact channel name (``#``-prefixed),
+# the literal ``*`` (any channel including nick-scoped), or the empty string
+# (nick-scoped events only). Anything else is rejected so subscribers don't
+# silently bind a filter that never matches.
+_CHANNEL_FILTER_RE = re.compile(r"^(#[^\s,]+|\*|)$")
+
+
+# ---------------------------------------------------------------------------
+# Filter-parameter dispatch table for EVENTSUB
+# ---------------------------------------------------------------------------
+# Each handler receives the partially-built ``filters`` dict and the value
+# from one ``key=value`` token; it mutates ``filters`` and returns either
+# ``None`` on success or an error-reason string suitable for
+# ``EVENTERR <sub-id> :<reason>``. ``Client._parse_eventsub_filters`` walks
+# the tokens and dispatches via :data:`FILTER_HANDLERS`.
+
+
+def _set_type_glob(filters: dict, value: str) -> str | None:
+    filters["type_glob"] = value or "*"
+    return None
+
+
+def _set_channel(filters: dict, value: str) -> str | None:
+    if not _CHANNEL_FILTER_RE.match(value):
+        return f"invalid-channel-filter {value}"
+    filters["channel"] = CHANNEL_NICK_SCOPED_ONLY if value == "" else value
+    return None
+
+
+def _set_nick_glob(filters: dict, value: str) -> str | None:
+    filters["nick_glob"] = value or "*"
+    return None
+
+
+FILTER_HANDLERS: dict[str, Callable[[dict, str], "str | None"]] = {
+    "type": _set_type_glob,
+    "channel": _set_channel,
+    "nick": _set_nick_glob,
+}
 
 
 @dataclass
@@ -161,10 +202,12 @@ class SubscriptionRegistry:
         ``EVENTERR <sub-id> :backpressure-overflow`` line, and remove the
         subscription from the registry. The bot's connection stays open.
         """
-        # list() snapshots are taken because send_raw can yield and concurrent
-        # add()/remove() calls may mutate the dicts mid-iteration.
-        for client, per_client in list(self._subs.items()):
-            for sub in list(per_client.values()):
+        # ``dispatch`` may call ``_handle_overflow`` which awaits
+        # ``client.send_raw``; while that yields, another coroutine can call
+        # ``add`` or ``remove`` and mutate the dicts. The ``list()`` snapshots
+        # avoid ``RuntimeError: dictionary changed size during iteration``.
+        for client, per_client in list(self._subs.items()):  # NOSONAR python:S7504: defensive snapshot vs. concurrent mutation
+            for sub in list(per_client.values()):  # NOSONAR python:S7504: defensive snapshot vs. concurrent mutation
                 if sub.dropped:
                     continue
                 if not sub.matches(event):
@@ -196,35 +239,34 @@ class SubscriptionRegistry:
 
         server_name = client.server.config.name
 
-        try:
-            while True:
-                event = await sub.queue.get()
-                if sub.dropped:
-                    return
+        # ``CancelledError`` (raised when ``remove``/``remove_client`` cancels
+        # the drain task) propagates out of this coroutine naturally — no
+        # cleanup is needed because the registry already removed the
+        # subscription before cancelling the task.
+        while True:
+            event = await sub.queue.get()
+            if sub.dropped:
+                return
 
-                type_wire = str(event.type)
-                target = event.channel if event.channel is not None else "*"
-                envelope = IRCd._build_event_envelope(event)
-                encoded = IRCd._encode_event_data(envelope, type_wire)
-                line = (
-                    f":{server_name} {EVENT} {sub.sub_id} {type_wire} "
-                    f"{target} {event.nick} :{encoded}"
+            type_wire = str(event.type)
+            target = event.channel if event.channel is not None else "*"
+            envelope = IRCd._build_event_envelope(event)
+            encoded = IRCd._encode_event_data(envelope, type_wire)
+            line = (
+                f":{server_name} {EVENT} {sub.sub_id} {type_wire} "
+                f"{target} {event.nick} :{encoded}"
+            )
+            try:
+                await client.send_raw(line)
+            except Exception:
+                # Connection is gone or send failed; let the disconnect
+                # cleanup path remove this subscription.
+                logger.debug(
+                    "EVENT send to %s sub %s failed; awaiting disconnect cleanup",
+                    getattr(client, "nick", "<?>"),
+                    sub.sub_id,
                 )
-                try:
-                    await client.send_raw(line)
-                except Exception:
-                    # Connection is gone or send failed; let the disconnect
-                    # cleanup path remove this subscription.
-                    logger.debug(
-                        "EVENT send to %s sub %s failed; awaiting disconnect cleanup",
-                        getattr(client, "nick", "<?>"),
-                        sub.sub_id,
-                    )
-                    return
-        except asyncio.CancelledError:
-            # Drain task cancelled by ``remove`` or ``remove_client`` —
-            # propagate so asyncio cleanup runs as normal.
-            raise
+                return
 
 
 __all__ = [

--- a/agentirc/_internal/event_subscriptions.py
+++ b/agentirc/_internal/event_subscriptions.py
@@ -1,0 +1,239 @@
+"""Per-client event subscription registry for the bot extension API (9.5.0).
+
+Public-facing wire format and verb syntax are described in the design spec at
+``docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`` § Decision B.
+This module is internal — consumers interact via the ``EVENTSUB``/``EVENTUNSUB``
+IRC verbs handled by :class:`agentirc.client.Client`.
+
+Design points:
+
+- One :class:`Subscription` per ``sub-id`` per client. Multiple concurrent
+  subscriptions per client are allowed; each gets its own bounded queue and
+  its own drain task.
+- Filter fields are AND-ed; ``type`` and ``nick`` accept ``fnmatch``-style
+  globs (``*``/``?``/``[]``); ``channel`` is exact match (or ``"*"`` for any
+  channel, or ``""`` for nick-scoped events only).
+- Backpressure: a per-subscription ``asyncio.Queue`` bounded by
+  ``ServerConfig.event_subscription_queue_max``. On overflow, the registry
+  sends ``EVENTERR <sub-id> :backpressure-overflow`` and removes the
+  subscription. The connection itself stays open — the bot can re-subscribe
+  with the same or a fresh ``sub-id`` and use ``BACKFILL`` to recover.
+- The drain task encodes events via :func:`agentirc.ircd.IRCd._build_event_envelope`
+  + :func:`agentirc.ircd.IRCd._encode_event_data`, so the ``EVENT`` line on the
+  wire carries the same canonical 5-field envelope as the federated ``SEVENT``
+  payload and the IRCv3 ``event-data`` tag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agentirc.client import Client
+    from agentirc.protocol import Event
+
+logger = logging.getLogger(__name__)
+
+
+# A per-subscription channel filter that matches every channel, including the
+# nick-scoped ``None`` case.
+CHANNEL_ANY = "*"
+# A per-subscription channel filter that matches only nick-scoped events
+# (events with ``event.channel is None``).
+CHANNEL_NICK_SCOPED_ONLY = ""
+
+
+@dataclass
+class Subscription:
+    """A single subscription owned by a client.
+
+    Constructed by :meth:`SubscriptionRegistry.add`; do not instantiate
+    directly. ``queue`` and ``drain_task`` are populated by the registry.
+    """
+
+    sub_id: str
+    type_glob: str = "*"
+    channel: str = CHANNEL_ANY
+    nick_glob: str = "*"
+    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    drain_task: asyncio.Task | None = None
+    dropped: bool = False
+
+    def matches(self, event: Event) -> bool:
+        """Return True if *event* satisfies the AND-ed filter fields."""
+        type_str = str(event.type)
+        if self.type_glob != "*" and not fnmatch.fnmatchcase(type_str, self.type_glob):
+            return False
+        if self.channel != CHANNEL_ANY:
+            if self.channel == CHANNEL_NICK_SCOPED_ONLY:
+                if event.channel is not None:
+                    return False
+            else:
+                if event.channel != self.channel:
+                    return False
+        if self.nick_glob != "*" and not fnmatch.fnmatchcase(event.nick, self.nick_glob):
+            return False
+        return True
+
+
+class SubscriptionRegistry:
+    """Routes events to per-client subscription queues.
+
+    Owned by :class:`agentirc.ircd.IRCd`. ``IRCd.emit_event`` calls
+    :meth:`dispatch` on every event; subscriber clients drain their per-sub
+    queues via background tasks.
+    """
+
+    def __init__(self, *, queue_max: int = 1024) -> None:
+        self._subs: dict[Client, dict[str, Subscription]] = {}
+        self._queue_max = queue_max
+
+    @property
+    def queue_max(self) -> int:
+        return self._queue_max
+
+    def get(self, client: Client, sub_id: str) -> Subscription | None:
+        return self._subs.get(client, {}).get(sub_id)
+
+    def list_for_client(self, client: Client) -> list[Subscription]:
+        return list(self._subs.get(client, {}).values())
+
+    def add(
+        self,
+        client: Client,
+        sub_id: str,
+        *,
+        type_glob: str = "*",
+        channel: str = CHANNEL_ANY,
+        nick_glob: str = "*",
+    ) -> Subscription | None:
+        """Register a new subscription. Returns None on sub-id collision.
+
+        The caller is responsible for sending the appropriate ``EVENTERR``
+        when the result is ``None``.
+        """
+        per_client = self._subs.setdefault(client, {})
+        if sub_id in per_client:
+            return None
+        sub = Subscription(
+            sub_id=sub_id,
+            type_glob=type_glob,
+            channel=channel,
+            nick_glob=nick_glob,
+            queue=asyncio.Queue(maxsize=self._queue_max),
+        )
+        per_client[sub_id] = sub
+        sub.drain_task = asyncio.create_task(
+            self._drain(client, sub),
+            name=f"event-sub-drain[{sub_id}]",
+        )
+        return sub
+
+    def remove(self, client: Client, sub_id: str) -> bool:
+        """Cancel and forget *sub_id* on *client*. Returns True on hit."""
+        per_client = self._subs.get(client)
+        if not per_client or sub_id not in per_client:
+            return False
+        sub = per_client.pop(sub_id)
+        sub.dropped = True
+        if sub.drain_task is not None and not sub.drain_task.done():
+            sub.drain_task.cancel()
+        if not per_client:
+            self._subs.pop(client, None)
+        return True
+
+    def remove_client(self, client: Client) -> None:
+        """Cancel every subscription owned by *client*. Called on disconnect."""
+        per_client = self._subs.pop(client, {})
+        for sub in per_client.values():
+            sub.dropped = True
+            if sub.drain_task is not None and not sub.drain_task.done():
+                sub.drain_task.cancel()
+
+    async def dispatch(self, event: Event) -> None:
+        """Enqueue *event* on every matching subscription.
+
+        On queue overflow, mark the subscription dropped, send the bot an
+        ``EVENTERR <sub-id> :backpressure-overflow`` line, and remove the
+        subscription from the registry. The bot's connection stays open.
+        """
+        # list() snapshots are taken because send_raw can yield and concurrent
+        # add()/remove() calls may mutate the dicts mid-iteration.
+        for client, per_client in list(self._subs.items()):
+            for sub in list(per_client.values()):
+                if sub.dropped:
+                    continue
+                if not sub.matches(event):
+                    continue
+                try:
+                    sub.queue.put_nowait(event)
+                except asyncio.QueueFull:
+                    await self._handle_overflow(client, sub)
+
+    async def _handle_overflow(self, client: Client, sub: Subscription) -> None:
+        sub.dropped = True
+        try:
+            await client.send_raw(f"EVENTERR {sub.sub_id} :backpressure-overflow")
+        except Exception:
+            logger.exception(
+                "Failed to send backpressure-overflow EVENTERR for sub %s",
+                sub.sub_id,
+            )
+        self.remove(client, sub.sub_id)
+
+    async def _drain(self, client: Client, sub: Subscription) -> None:
+        """Pull events off *sub.queue* and send them as ``EVENT`` lines.
+
+        Imports :mod:`agentirc.ircd` and :mod:`agentirc.protocol` lazily to
+        avoid an import cycle (``ircd.py`` instantiates this registry).
+        """
+        from agentirc.ircd import IRCd
+        from agentirc.protocol import EVENT
+
+        server_name = client.server.config.name
+
+        while True:
+            try:
+                event = await sub.queue.get()
+            except asyncio.CancelledError:
+                return
+
+            if sub.dropped:
+                return
+
+            type_wire = str(event.type)
+            target = event.channel if event.channel is not None else "*"
+            envelope = IRCd._build_event_envelope(event)
+            encoded = IRCd._encode_event_data(envelope, type_wire)
+            line = (
+                f":{server_name} {EVENT} {sub.sub_id} {type_wire} "
+                f"{target} {event.nick} :{encoded}"
+            )
+            try:
+                await client.send_raw(line)
+            except Exception:
+                # Connection is gone or send failed; let the disconnect
+                # cleanup path remove this subscription.
+                logger.debug(
+                    "EVENT send to %s sub %s failed; awaiting disconnect cleanup",
+                    getattr(client, "nick", "<?>"),
+                    sub.sub_id,
+                )
+                return
+
+
+__all__ = [
+    "CHANNEL_ANY",
+    "CHANNEL_NICK_SCOPED_ONLY",
+    "Subscription",
+    "SubscriptionRegistry",
+]
+
+
+# Re-export ``Any`` to satisfy strict-import linters that flag the typing import
+# above. (Subscription.queue is parameterized in docstrings only.)
+_ = Any

--- a/agentirc/_internal/virtual_client.py
+++ b/agentirc/_internal/virtual_client.py
@@ -27,6 +27,13 @@ class VirtualClient:
     in channel.members, NAMES, WHO, and WHOIS transparently.
     """
 
+    # The in-process system bot is treated identically to a real CAP-bot by
+    # the bot-extension code paths (silent JOIN/PART/QUIT broadcasts,
+    # excluded from the auto-op predicate, ``+`` prefix in NAMES, ``B`` flag
+    # in WHO). Class-level attribute so every instance gets the same caps;
+    # individual VirtualClients don't negotiate caps the way real Clients do.
+    caps: frozenset[str] = frozenset({"agentirc.io/bot", "message-tags"})
+
     def __init__(self, nick: str, user: str, server: IRCd):
         self.nick = nick
         self.user = user

--- a/agentirc/_internal/virtual_client.py
+++ b/agentirc/_internal/virtual_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from agentirc.protocol import BOT_CAP
 from agentirc.skill import Event, EventType
 from agentirc._internal.protocol.message import Message
 
@@ -27,12 +28,16 @@ class VirtualClient:
     in channel.members, NAMES, WHO, and WHOIS transparently.
     """
 
-    # The in-process system bot is treated identically to a real CAP-bot by
-    # the bot-extension code paths (silent JOIN/PART/QUIT broadcasts,
-    # excluded from the auto-op predicate, ``+`` prefix in NAMES, ``B`` flag
-    # in WHO). Class-level attribute so every instance gets the same caps;
-    # individual VirtualClients don't negotiate caps the way real Clients do.
-    caps: frozenset[str] = frozenset({"agentirc.io/bot", "message-tags"})
+    # The in-process system bot is treated identically to a real CAP-bot
+    # everywhere: external code paths (``Channel._local_members``,
+    # ``Channel.get_prefix``, ``Client._build_who_flags``) read this attr
+    # via ``getattr(member, "caps", ...)`` and apply the no-auto-op,
+    # ``+``-prefix, and ``B``-flag rules; the methods on this class
+    # (``join_channel``/``part_channel``) check it themselves to suppress
+    # their own JOIN/PART broadcasts to other channel members. Class-level
+    # so every instance gets the same caps; VirtualClients don't negotiate
+    # caps the way real Clients do.
+    caps: frozenset[str] = frozenset({BOT_CAP, "message-tags"})
 
     def __init__(self, nick: str, user: str, server: IRCd):
         self.nick = nick
@@ -70,14 +75,19 @@ class VirtualClient:
         # Ensure bot is never auto-promoted to operator
         channel.operators.discard(self)
 
-        join_msg = Message(
-            prefix=self.prefix,
-            command="JOIN",
-            params=[channel_name],
-        )
-        for member in [*channel.members]:
-            if member is not self:
-                await member.send(join_msg)
+        # Bot-CAP clients (the entire VirtualClient class) skip the
+        # per-member JOIN broadcast — silent presence to other members.
+        # Channel membership above is already added; the user.join event
+        # below still fires so EVENTSUB subscribers see it.
+        if BOT_CAP not in self.caps:
+            join_msg = Message(
+                prefix=self.prefix,
+                command="JOIN",
+                params=[channel_name],
+            )
+            for member in [*channel.members]:
+                if member is not self:
+                    await member.send(join_msg)
 
         if emit_event:
             await self.server.emit_event(
@@ -90,14 +100,17 @@ class VirtualClient:
         if not channel or self not in channel.members:
             return
 
-        part_msg = Message(
-            prefix=self.prefix,
-            command="PART",
-            params=[channel_name],
-        )
-        for member in [*channel.members]:
-            if member is not self:
-                await member.send(part_msg)
+        # Symmetric with join_channel — bot-CAP clients skip the per-member
+        # PART broadcast. The user.part event below still fires.
+        if BOT_CAP not in self.caps:
+            part_msg = Message(
+                prefix=self.prefix,
+                command="PART",
+                params=[channel_name],
+            )
+            for member in [*channel.members]:
+                if member is not self:
+                    await member.send(part_msg)
 
         await self.server.emit_event(
             Event(

--- a/agentirc/channel.py
+++ b/agentirc/channel.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Union
 
+from agentirc.protocol import BOT_CAP
+
 if TYPE_CHECKING:
     from agentirc.client import Client
     from agentirc.remote_client import RemoteClient
@@ -53,7 +55,7 @@ class Channel:
             m
             for m in self.members
             if not isinstance(m, (RemoteClient, VirtualClient))
-            and "agentirc.io/bot" not in getattr(m, "caps", frozenset())
+            and BOT_CAP not in getattr(m, "caps", frozenset())
         }
 
     def add(self, client: Client) -> None:
@@ -67,7 +69,7 @@ class Channel:
 
             is_op_eligible = (
                 not isinstance(client, (RemoteClient, VirtualClient))
-                and "agentirc.io/bot" not in getattr(client, "caps", frozenset())
+                and BOT_CAP not in getattr(client, "caps", frozenset())
             )
             if is_op_eligible:
                 self.operators.add(client)
@@ -100,6 +102,6 @@ class Channel:
         # so vanilla IRC clients filter bots from presence panels by
         # checking the ``+`` prefix. Op wins on conflict (above), so an
         # explicitly-opped bot still renders as ``@``.
-        if "agentirc.io/bot" in getattr(client, "caps", frozenset()):
+        if BOT_CAP in getattr(client, "caps", frozenset()):
             return "+"
         return ""

--- a/agentirc/channel.py
+++ b/agentirc/channel.py
@@ -40,18 +40,36 @@ class Channel:
         return self.room_id is not None
 
     def _local_members(self) -> set[Client]:
-        """Return only local (non-remote, non-virtual) members."""
+        """Return only local (non-remote, non-virtual, non-bot-CAP) members.
+
+        Used as the auto-op eligibility predicate by :meth:`add`. Bot-CAP
+        clients are excluded so a bot joining an empty channel never becomes
+        op — a human joining later does.
+        """
         from agentirc.remote_client import RemoteClient
         from agentirc._internal.virtual_client import VirtualClient
 
-        return {m for m in self.members if not isinstance(m, (RemoteClient, VirtualClient))}
+        return {
+            m
+            for m in self.members
+            if not isinstance(m, (RemoteClient, VirtualClient))
+            and "agentirc.io/bot" not in getattr(m, "caps", frozenset())
+        }
 
     def add(self, client: Client) -> None:
-        # Only grant op to the first LOCAL joiner
+        # Only grant op to the first LOCAL joiner. Bot-CAP clients
+        # (real or VirtualClient) are excluded — they never auto-op,
+        # so a bot joining an empty channel stays unprivileged and
+        # the next human becomes op.
         if not self._local_members():
             from agentirc.remote_client import RemoteClient
+            from agentirc._internal.virtual_client import VirtualClient
 
-            if not isinstance(client, RemoteClient):
+            is_op_eligible = (
+                not isinstance(client, (RemoteClient, VirtualClient))
+                and "agentirc.io/bot" not in getattr(client, "caps", frozenset())
+            )
+            if is_op_eligible:
                 self.operators.add(client)
         self.members.add(client)
 
@@ -76,5 +94,12 @@ class Channel:
         if client in self.operators:
             return "@"
         if client in self.voiced:
+            return "+"
+        # Bot-CAP clients render with the voice prefix in NAMES output —
+        # the closest standard IRC mode for "non-disruptive participant",
+        # so vanilla IRC clients filter bots from presence panels by
+        # checking the ``+`` prefix. Op wins on conflict (above), so an
+        # explicitly-opped bot still renders as ``@``.
+        if "agentirc.io/bot" in getattr(client, "caps", frozenset()):
             return "+"
         return ""

--- a/agentirc/client.py
+++ b/agentirc/client.py
@@ -38,6 +38,7 @@ from agentirc._internal.telemetry.context import (
 )
 from agentirc._internal.telemetry.context import inject_traceparent as _inject_traceparent
 from agentirc.channel import Channel
+from agentirc.protocol import BOT_CAP, EVENTERR
 from agentirc.skill import Event, EventType
 
 # OTEL instrumentation name. Kept verbatim ("culture.agentirc") because
@@ -316,7 +317,7 @@ class Client:
     # Capabilities advertised in CAP LS and accepted in CAP REQ. Adding
     # a new cap here is a minor bump per docs/api-stability.md; removing
     # one is a major bump.
-    _SUPPORTED_CAPS: frozenset[str] = frozenset({"message-tags", "agentirc.io/bot"})
+    _SUPPORTED_CAPS: frozenset[str] = frozenset({"message-tags", BOT_CAP})
 
     async def _handle_cap(self, msg: Message) -> None:
         sub = msg.params[0].upper() if msg.params else ""
@@ -470,7 +471,7 @@ class Client:
             # but no human-visible JOIN line hits other channel members.
             # (Channel membership IS added regardless; topic + NAMES below
             # still go to the joining client so it knows the join succeeded.)
-            if "agentirc.io/bot" not in self.caps:
+            if BOT_CAP not in self.caps:
                 join_msg = Message(prefix=self.prefix, command="JOIN", params=[channel_name])
                 for member in [*channel.members]:
                     await member.send(join_msg)
@@ -512,7 +513,7 @@ class Client:
             part_params = [channel_name, reason] if reason else [channel_name]
             # Bot-CAP clients skip the broadcast — symmetrical with the
             # silent JOIN behaviour. The user.part event still fires.
-            if "agentirc.io/bot" not in self.caps:
+            if BOT_CAP not in self.caps:
                 part_msg = Message(prefix=self.prefix, command="PART", params=part_params)
                 for member in [*channel.members]:
                     await member.send(part_msg)
@@ -977,7 +978,7 @@ class Client:
         # Bot-CAP clients get a `B` flag in the user-modes column so vanilla
         # IRC clients can filter bots from presence panels by checking for
         # `B` (agentirc-extension flag, composes with the standard H/A flags).
-        if "agentirc.io/bot" in getattr(member, "caps", frozenset()):
+        if BOT_CAP in getattr(member, "caps", frozenset()):
             flags += "B"
         if channel and channel.is_operator(member):
             flags += "@"
@@ -1075,7 +1076,7 @@ class Client:
         channel_names = [ch.name for ch in self.channels]
         # Bot-CAP clients skip the broadcast — symmetrical with the silent
         # JOIN/PART behaviour. The user.quit event still fires below.
-        if "agentirc.io/bot" not in self.caps:
+        if BOT_CAP not in self.caps:
             for channel in [*self.channels]:
                 for member in [*channel.members]:
                     if member is not self and member not in notified:
@@ -1096,108 +1097,144 @@ class Client:
     # --- Bot extension verbs (9.5.0) ---
     # Spec: docs/superpowers/specs/2026-05-01-bot-extension-api-design.md
     # § Decision B (EVENTSUB/EVENTUNSUB) and § Decision E (EVENTPUB).
-    # All three require the ``agentirc.io/bot`` capability; without it,
-    # the server replies ``EVENTERR <id> :bot-capability-required`` and
-    # nothing else happens.
+    # All three require:
+    #   1. The ``agentirc.io/bot`` capability — without it, the server
+    #      replies ``EVENTERR <id> :bot-capability-required``.
+    #   2. A registered connection (post-NICK/USER) — without it, the
+    #      server replies ``EVENTERR <id> :not-registered``. This guards
+    #      against anonymous sockets injecting events with ``nick=None``
+    #      or pulling the full event stream before claiming an identity.
 
     _SUB_ID_RE = re.compile(r"^[A-Za-z0-9._:\-]{1,32}$")
+    # Channel filter accepts: an exact channel name (``#``-prefixed), the
+    # literal ``*`` (any channel including nick-scoped), or empty string
+    # (nick-scoped events only). Anything else is a typo and gets rejected
+    # so subscribers don't silently bind a filter that never matches.
+    _CHANNEL_FILTER_RE = re.compile(r"^(#[^\s,]+|\*|)$")
 
-    async def _handle_eventsub(self, msg: Message) -> None:
-        sub_id = msg.params[0] if msg.params else "?"
-        if "agentirc.io/bot" not in self.caps:
-            await self.send_raw(f"EVENTERR {sub_id} :bot-capability-required")
-            return
-        if not msg.params:
-            await self.send_raw("EVENTERR ? :missing-sub-id")
-            return
-        if not self._SUB_ID_RE.match(sub_id):
-            await self.send_raw(f"EVENTERR {sub_id} :invalid-sub-id")
-            return
+    async def _bot_verb_gate(self, verb_id: str) -> bool:
+        """Common bot-CAP + registration gate for EVENTSUB/EVENTUNSUB/EVENTPUB.
 
+        Sends the appropriate ``EVENTERR`` and returns ``False`` on
+        rejection; returns ``True`` if the caller may proceed.
+        """
+        if BOT_CAP not in self.caps:
+            await self.send_raw(f"{EVENTERR} {verb_id} :bot-capability-required")
+            return False
+        if not self._registered:
+            await self.send_raw(f"{EVENTERR} {verb_id} :not-registered")
+            return False
+        return True
+
+    @staticmethod
+    def _parse_eventsub_filters(tokens: list[str]) -> tuple[dict, str | None]:
+        """Parse EVENTSUB filter tokens. Returns (filters, error_reason).
+
+        ``error_reason`` is ``None`` on success; otherwise a string suitable
+        for ``EVENTERR <sub-id> :<error_reason>``. Detects unknown filter
+        keys, duplicate filter keys (per spec, each parameter appears at
+        most once), malformed tokens, and invalid channel-filter format.
+        """
         from agentirc._internal.event_subscriptions import (
             CHANNEL_ANY,
             CHANNEL_NICK_SCOPED_ONLY,
         )
 
-        type_glob = "*"
-        channel = CHANNEL_ANY
-        nick_glob = "*"
-        for token in msg.params[1:]:
+        filters: dict = {"type_glob": "*", "channel": CHANNEL_ANY, "nick_glob": "*"}
+        seen: set[str] = set()
+        for token in tokens:
             if "=" not in token:
-                await self.send_raw(f"EVENTERR {sub_id} :invalid-filter {token}")
-                return
+                return filters, f"invalid-filter {token}"
             key, value = token.split("=", 1)
+            if key in seen:
+                return filters, f"duplicate-filter {key}"
+            seen.add(key)
             if key == "type":
-                type_glob = value or "*"
+                filters["type_glob"] = value or "*"
             elif key == "channel":
-                # `channel=` (empty value) → only nick-scoped events match.
-                # `channel=*` → any channel including None.
-                # `channel=#room` → exact match.
+                if not Client._CHANNEL_FILTER_RE.match(value):
+                    return filters, f"invalid-channel-filter {value}"
                 if value == "":
-                    channel = CHANNEL_NICK_SCOPED_ONLY
+                    filters["channel"] = CHANNEL_NICK_SCOPED_ONLY
                 else:
-                    channel = value
+                    filters["channel"] = value
             elif key == "nick":
-                nick_glob = value or "*"
+                filters["nick_glob"] = value or "*"
             else:
-                await self.send_raw(f"EVENTERR {sub_id} :unknown-filter {key}")
-                return
+                return filters, f"unknown-filter {key}"
+        return filters, None
 
-        sub = self.server.subscription_registry.add(
-            self,
-            sub_id,
-            type_glob=type_glob,
-            channel=channel,
-            nick_glob=nick_glob,
-        )
-        if sub is None:
-            await self.send_raw(f"EVENTERR {sub_id} :sub-id-in-use")
+    async def _handle_eventsub(self, msg: Message) -> None:
+        sub_id = msg.params[0] if msg.params else "?"
+        if not await self._bot_verb_gate(sub_id):
             return
+        if not msg.params:
+            await self.send_raw(f"{EVENTERR} ? :missing-sub-id")
+            return
+        if not self._SUB_ID_RE.match(sub_id):
+            await self.send_raw(f"{EVENTERR} {sub_id} :invalid-sub-id")
+            return
+
+        filters, error = self._parse_eventsub_filters(msg.params[1:])
+        if error is not None:
+            await self.send_raw(f"{EVENTERR} {sub_id} :{error}")
+            return
+
+        sub = self.server.subscription_registry.add(self, sub_id, **filters)
+        if sub is None:
+            await self.send_raw(f"{EVENTERR} {sub_id} :sub-id-in-use")
 
     async def _handle_eventunsub(self, msg: Message) -> None:
+        sub_id = msg.params[0] if msg.params else "?"
+        if not await self._bot_verb_gate(sub_id):
+            return
         if not msg.params:
             return
-        sub_id = msg.params[0]
         # Silent on success — no more EVENT lines for this sub-id is the signal.
         self.server.subscription_registry.remove(self, sub_id)
 
     async def _handle_eventpub(self, msg: Message) -> None:
         type_str = msg.params[0] if msg.params else "?"
-        if "agentirc.io/bot" not in self.caps:
-            await self.send_raw(f"EVENTERR {type_str} :bot-capability-required")
+        if not await self._bot_verb_gate(type_str):
             return
         if len(msg.params) < 3:
-            await self.send_raw(f"EVENTERR {type_str} :invalid-eventpub-syntax")
+            await self.send_raw(f"{EVENTERR} {type_str} :invalid-eventpub-syntax")
             return
         type_str, target, b64 = msg.params[0], msg.params[1], msg.params[2]
         if not EVENT_TYPE_RE.match(type_str):
-            await self.send_raw(f"EVENTERR {type_str} :invalid-type")
+            await self.send_raw(f"{EVENTERR} {type_str} :invalid-type")
             return
 
         channel = None if target == "*" else target
         if channel is not None and channel not in self.server.channels:
-            await self.send_raw(f"EVENTERR {type_str} :no-such-channel")
+            await self.send_raw(f"{EVENTERR} {type_str} :no-such-channel")
             return
 
+        # ``base64.b64decode`` can raise ``binascii.Error`` (a subclass of
+        # ``ValueError``) for malformed input AND a few unrelated errors
+        # for non-ASCII; ``json.loads`` raises ``json.JSONDecodeError`` (a
+        # subclass of ``ValueError``). The unhandled-exception path would
+        # tear down the connection task, so catch broadly.
         try:
             data = json.loads(base64.b64decode(b64))
-        except (ValueError, TypeError):
-            await self.send_raw(f"EVENTERR {type_str} :invalid-payload")
+        except Exception:
+            await self.send_raw(f"{EVENTERR} {type_str} :invalid-payload")
             return
         if not isinstance(data, dict):
-            await self.send_raw(f"EVENTERR {type_str} :invalid-payload")
+            await self.send_raw(f"{EVENTERR} {type_str} :invalid-payload")
             return
 
         # Strip `_`-prefixed keys (server-internal metadata like `_render`,
         # `_origin`). nick and timestamp are server-set so bots cannot spoof
         # the actor or wall-clock — peers across federation see consistent
-        # values.
+        # values. ``self.nick`` is guaranteed non-None by the registration
+        # gate above, but coerce defensively.
         data = {k: v for k, v in data.items() if not k.startswith("_")}
 
         ev = Event(
             type=type_str,
             channel=channel,
-            nick=self.nick,
+            nick=self.nick or "",
             data=data,
             timestamp=time.time(),
         )

--- a/agentirc/client.py
+++ b/agentirc/client.py
@@ -14,6 +14,8 @@ client.
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import logging
 import re
 import time
@@ -24,7 +26,7 @@ from opentelemetry.context import Context as _OtelContext
 from opentelemetry.trace import Span as _OtelSpan
 
 from agentirc._internal.aio import maybe_await
-from agentirc._internal.constants import SYSTEM_USER_PREFIX
+from agentirc._internal.constants import EVENT_TYPE_RE, SYSTEM_USER_PREFIX
 from agentirc._internal.protocol import replies
 from agentirc._internal.protocol.message import Message
 from agentirc._internal.telemetry.audit import utc_iso_timestamp as _utc_iso_timestamp
@@ -311,16 +313,21 @@ class Client:
     def _handle_pong(self, msg: Message) -> None:
         pass  # Client responding to our ping
 
+    # Capabilities advertised in CAP LS and accepted in CAP REQ. Adding
+    # a new cap here is a minor bump per docs/api-stability.md; removing
+    # one is a major bump.
+    _SUPPORTED_CAPS: frozenset[str] = frozenset({"message-tags", "agentirc.io/bot"})
+
     async def _handle_cap(self, msg: Message) -> None:
         sub = msg.params[0].upper() if msg.params else ""
         if sub == "LS":
+            cap_list = " ".join(sorted(self._SUPPORTED_CAPS))
             await self.send_raw(
-                f":{self.server.config.name} CAP {self.nick or '*'} LS :message-tags"
+                f":{self.server.config.name} CAP {self.nick or '*'} LS :{cap_list}"
             )
         elif sub == "REQ":
             requested = msg.params[1].split() if len(msg.params) >= 2 else []
-            supported = {"message-tags"}
-            if all(cap in supported for cap in requested):
+            if all(cap in self._SUPPORTED_CAPS for cap in requested):
                 self.caps.update(requested)
                 await self.send_raw(
                     f":{self.server.config.name} CAP {self.nick or '*'}"
@@ -457,10 +464,16 @@ class Client:
             channel.add(self)
             self.channels.add(channel)
 
-            # Notify all channel members (including self)
-            join_msg = Message(prefix=self.prefix, command="JOIN", params=[channel_name])
-            for member in [*channel.members]:
-                await member.send(join_msg)
+            # Notify all channel members (including self).
+            # Bot-CAP clients skip the broadcast entirely — the user.join
+            # event still fires below, so EVENTSUB subscribers see the join,
+            # but no human-visible JOIN line hits other channel members.
+            # (Channel membership IS added regardless; topic + NAMES below
+            # still go to the joining client so it knows the join succeeded.)
+            if "agentirc.io/bot" not in self.caps:
+                join_msg = Message(prefix=self.prefix, command="JOIN", params=[channel_name])
+                for member in [*channel.members]:
+                    await member.send(join_msg)
 
             # Send topic if set
             if channel.topic:
@@ -497,9 +510,12 @@ class Client:
                 return
 
             part_params = [channel_name, reason] if reason else [channel_name]
-            part_msg = Message(prefix=self.prefix, command="PART", params=part_params)
-            for member in [*channel.members]:
-                await member.send(part_msg)
+            # Bot-CAP clients skip the broadcast — symmetrical with the
+            # silent JOIN behaviour. The user.part event still fires.
+            if "agentirc.io/bot" not in self.caps:
+                part_msg = Message(prefix=self.prefix, command="PART", params=part_params)
+                for member in [*channel.members]:
+                    await member.send(part_msg)
 
             await self.server.emit_event(
                 Event(
@@ -958,6 +974,11 @@ class Client:
 
     def _build_who_flags(self, member, channel) -> str:
         flags = "H"
+        # Bot-CAP clients get a `B` flag in the user-modes column so vanilla
+        # IRC clients can filter bots from presence panels by checking for
+        # `B` (agentirc-extension flag, composes with the standard H/A flags).
+        if "agentirc.io/bot" in getattr(member, "caps", frozenset()):
+            flags += "B"
         if channel and channel.is_operator(member):
             flags += "@"
         elif channel and channel.is_voiced(member):
@@ -1052,11 +1073,14 @@ class Client:
 
         notified: set[Client] = set()
         channel_names = [ch.name for ch in self.channels]
-        for channel in [*self.channels]:
-            for member in [*channel.members]:
-                if member is not self and member not in notified:
-                    await member.send(quit_msg)
-                    notified.add(member)
+        # Bot-CAP clients skip the broadcast — symmetrical with the silent
+        # JOIN/PART behaviour. The user.quit event still fires below.
+        if "agentirc.io/bot" not in self.caps:
+            for channel in [*self.channels]:
+                for member in [*channel.members]:
+                    if member is not self and member not in notified:
+                        await member.send(quit_msg)
+                        notified.add(member)
 
         await self.server.emit_event(
             Event(
@@ -1068,3 +1092,113 @@ class Client:
         )
 
         raise ConnectionError("Client quit")
+
+    # --- Bot extension verbs (9.5.0) ---
+    # Spec: docs/superpowers/specs/2026-05-01-bot-extension-api-design.md
+    # § Decision B (EVENTSUB/EVENTUNSUB) and § Decision E (EVENTPUB).
+    # All three require the ``agentirc.io/bot`` capability; without it,
+    # the server replies ``EVENTERR <id> :bot-capability-required`` and
+    # nothing else happens.
+
+    _SUB_ID_RE = re.compile(r"^[A-Za-z0-9._:\-]{1,32}$")
+
+    async def _handle_eventsub(self, msg: Message) -> None:
+        sub_id = msg.params[0] if msg.params else "?"
+        if "agentirc.io/bot" not in self.caps:
+            await self.send_raw(f"EVENTERR {sub_id} :bot-capability-required")
+            return
+        if not msg.params:
+            await self.send_raw("EVENTERR ? :missing-sub-id")
+            return
+        if not self._SUB_ID_RE.match(sub_id):
+            await self.send_raw(f"EVENTERR {sub_id} :invalid-sub-id")
+            return
+
+        from agentirc._internal.event_subscriptions import (
+            CHANNEL_ANY,
+            CHANNEL_NICK_SCOPED_ONLY,
+        )
+
+        type_glob = "*"
+        channel = CHANNEL_ANY
+        nick_glob = "*"
+        for token in msg.params[1:]:
+            if "=" not in token:
+                await self.send_raw(f"EVENTERR {sub_id} :invalid-filter {token}")
+                return
+            key, value = token.split("=", 1)
+            if key == "type":
+                type_glob = value or "*"
+            elif key == "channel":
+                # `channel=` (empty value) → only nick-scoped events match.
+                # `channel=*` → any channel including None.
+                # `channel=#room` → exact match.
+                if value == "":
+                    channel = CHANNEL_NICK_SCOPED_ONLY
+                else:
+                    channel = value
+            elif key == "nick":
+                nick_glob = value or "*"
+            else:
+                await self.send_raw(f"EVENTERR {sub_id} :unknown-filter {key}")
+                return
+
+        sub = self.server.subscription_registry.add(
+            self,
+            sub_id,
+            type_glob=type_glob,
+            channel=channel,
+            nick_glob=nick_glob,
+        )
+        if sub is None:
+            await self.send_raw(f"EVENTERR {sub_id} :sub-id-in-use")
+            return
+
+    async def _handle_eventunsub(self, msg: Message) -> None:
+        if not msg.params:
+            return
+        sub_id = msg.params[0]
+        # Silent on success — no more EVENT lines for this sub-id is the signal.
+        self.server.subscription_registry.remove(self, sub_id)
+
+    async def _handle_eventpub(self, msg: Message) -> None:
+        type_str = msg.params[0] if msg.params else "?"
+        if "agentirc.io/bot" not in self.caps:
+            await self.send_raw(f"EVENTERR {type_str} :bot-capability-required")
+            return
+        if len(msg.params) < 3:
+            await self.send_raw(f"EVENTERR {type_str} :invalid-eventpub-syntax")
+            return
+        type_str, target, b64 = msg.params[0], msg.params[1], msg.params[2]
+        if not EVENT_TYPE_RE.match(type_str):
+            await self.send_raw(f"EVENTERR {type_str} :invalid-type")
+            return
+
+        channel = None if target == "*" else target
+        if channel is not None and channel not in self.server.channels:
+            await self.send_raw(f"EVENTERR {type_str} :no-such-channel")
+            return
+
+        try:
+            data = json.loads(base64.b64decode(b64))
+        except (ValueError, TypeError):
+            await self.send_raw(f"EVENTERR {type_str} :invalid-payload")
+            return
+        if not isinstance(data, dict):
+            await self.send_raw(f"EVENTERR {type_str} :invalid-payload")
+            return
+
+        # Strip `_`-prefixed keys (server-internal metadata like `_render`,
+        # `_origin`). nick and timestamp are server-set so bots cannot spoof
+        # the actor or wall-clock — peers across federation see consistent
+        # values.
+        data = {k: v for k, v in data.items() if not k.startswith("_")}
+
+        ev = Event(
+            type=type_str,
+            channel=channel,
+            nick=self.nick,
+            data=data,
+            timestamp=time.time(),
+        )
+        await self.server.emit_event(ev)

--- a/agentirc/client.py
+++ b/agentirc/client.py
@@ -1106,11 +1106,6 @@ class Client:
     #      or pulling the full event stream before claiming an identity.
 
     _SUB_ID_RE = re.compile(r"^[A-Za-z0-9._:\-]{1,32}$")
-    # Channel filter accepts: an exact channel name (``#``-prefixed), the
-    # literal ``*`` (any channel including nick-scoped), or empty string
-    # (nick-scoped events only). Anything else is a typo and gets rejected
-    # so subscribers don't silently bind a filter that never matches.
-    _CHANNEL_FILTER_RE = re.compile(r"^(#[^\s,]+|\*|)$")
 
     async def _bot_verb_gate(self, verb_id: str) -> bool:
         """Common bot-CAP + registration gate for EVENTSUB/EVENTUNSUB/EVENTPUB.
@@ -1134,10 +1129,12 @@ class Client:
         for ``EVENTERR <sub-id> :<error_reason>``. Detects unknown filter
         keys, duplicate filter keys (per spec, each parameter appears at
         most once), malformed tokens, and invalid channel-filter format.
+        Per-key validation lives in
+        :data:`agentirc._internal.event_subscriptions.FILTER_HANDLERS`.
         """
         from agentirc._internal.event_subscriptions import (
             CHANNEL_ANY,
-            CHANNEL_NICK_SCOPED_ONLY,
+            FILTER_HANDLERS,
         )
 
         filters: dict = {"type_glob": "*", "channel": CHANNEL_ANY, "nick_glob": "*"}
@@ -1149,19 +1146,12 @@ class Client:
             if key in seen:
                 return filters, f"duplicate-filter {key}"
             seen.add(key)
-            if key == "type":
-                filters["type_glob"] = value or "*"
-            elif key == "channel":
-                if not Client._CHANNEL_FILTER_RE.match(value):
-                    return filters, f"invalid-channel-filter {value}"
-                if value == "":
-                    filters["channel"] = CHANNEL_NICK_SCOPED_ONLY
-                else:
-                    filters["channel"] = value
-            elif key == "nick":
-                filters["nick_glob"] = value or "*"
-            else:
+            handler = FILTER_HANDLERS.get(key)
+            if handler is None:
                 return filters, f"unknown-filter {key}"
+            error = handler(filters, value)
+            if error is not None:
+                return filters, error
         return filters, None
 
     async def _handle_eventsub(self, msg: Message) -> None:

--- a/agentirc/ircd.py
+++ b/agentirc/ircd.py
@@ -64,8 +64,16 @@ class IRCd:
         self._stopped = asyncio.Event()
         self._background_tasks: set[asyncio.Task] = set()
         # Bots
-        self.bot_manager = None  # set in start() if webhook_port configured
+        self.bot_manager = None  # set in start()
         self.system_client: VirtualClient | None = None
+        # Bot extension subscriptions (9.5.0): bots that negotiated
+        # ``agentirc.io/bot`` and issued EVENTSUB receive matching events
+        # via this registry's per-subscription bounded queues.
+        from agentirc._internal.event_subscriptions import SubscriptionRegistry
+
+        self.subscription_registry = SubscriptionRegistry(
+            queue_max=self.config.event_subscription_queue_max,
+        )
 
     async def start(self) -> None:
         logger.info("Registering default skills...")
@@ -89,9 +97,12 @@ class IRCd:
         )
         logger.info("Server awake on %s", self.config.name)
 
-        # Initialize bot manager and webhook HTTP listener
+        # Initialize bot manager. As of 9.5.0, ``webhook_port`` is no longer
+        # bound by agentirc — consumers (e.g. culture) host their own webhook
+        # listener if they need one. The field stays in ``ServerConfig`` so
+        # culture's ``~/.culture/server.yaml`` keeps loading unchanged; we
+        # just don't act on it. See docs/cli.md and docs/deployment.md.
         from agentirc._internal.bots.bot_manager import BotManager
-        from agentirc._internal.bots.http_listener import HttpListener
 
         logger.info("Loading bots...")
         self.bot_manager = BotManager(self)
@@ -108,26 +119,6 @@ class IRCd:
             self.config.host,
             self.config.port,
         )
-
-        self._http_listener = HttpListener(
-            self.bot_manager,
-            "127.0.0.1",
-            self.config.webhook_port,
-        )
-        try:
-            logger.info(
-                "Starting webhook listener on port %d...",
-                self.config.webhook_port,
-            )
-            await self._http_listener.start()
-        except OSError:
-            # Port unavailable (e.g. in tests using port 0 that got
-            # assigned an in-use ephemeral port). Non-fatal — bots
-            # still work, just without the HTTP endpoint.
-            logger.warning(
-                "Could not start webhook listener on port %d",
-                self.config.webhook_port,
-            )
 
         logger.info("Server ready")
 
@@ -251,6 +242,7 @@ class IRCd:
             if not origin_tag:
                 await self._relay_to_peers(event)
             await self._dispatch_to_bots(event)
+            await self.subscription_registry.dispatch(event)
             await self._surface_event_privmsg(event)
 
         render_ms = (time.perf_counter() - render_started) * 1000.0
@@ -447,11 +439,10 @@ class IRCd:
                 )
             except Exception:
                 logger.exception("failed to emit server.sleep")
-            # Stop bots and HTTP listener
+            # Stop bots. (As of 9.5.0, agentirc no longer owns the webhook
+            # HTTP listener — consumers host their own.)
             if self.bot_manager:
                 await self.bot_manager.stop_all()
-            if hasattr(self, "_http_listener") and self._http_listener:
-                await self._http_listener.stop()
             for skill in self.skills:
                 await skill.stop()
             # Cancel all pending retry tasks
@@ -667,6 +658,11 @@ class IRCd:
             channel.remove(client)
             if not channel.members and not channel.persistent:
                 del self.channels[channel.name]
+
+        # Cancel any EVENTSUB subscriptions owned by this client.
+        # Drain tasks would otherwise keep references and try to send to a
+        # closed StreamWriter on the next event.
+        self.subscription_registry.remove_client(client)
 
         nick = client.nick or "<unknown>"
         await self._emit_disconnect_events(nick, getattr(client, "modes", set()))

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -12,34 +12,47 @@ import only from these three modules.
 | [`agentirc.cli`](#agentirccli) | `main()`, `dispatch(argv) -> int` | Public, semver-tracked |
 | [`agentirc.protocol`](#agentircprotocol) | Verb constants, numeric reply codes, IRCv3/extension tag names | Public, semver-tracked |
 
-> **Bot extension API — phased rollout:**
->
-> - **9.5.0a1 (shipped):** `agentirc.protocol` exports the `Event`
->   dataclass, the `EventType` enum (now `StrEnum`), 20 per-type
->   `EVENT_TYPE_*` string constants, the `EVENTSUB`/`EVENTUNSUB`/
->   `EVENT`/`EVENTERR`/`EVENTPUB` verb constants, and the
->   `BOT_CAP = "agentirc.io/bot"` capability identifier.
->   `ServerConfig` gains the `event_subscription_queue_max: int = 1024`
->   field. **Declarations slice — symbols are importable but inert.**
-> - **9.5.0a2 (current alpha — wire-format slice):** `IRCd._build_event_payload`
->   replaced by `IRCd._build_event_envelope`. Federated `SEVENT` payload
->   and the IRCv3 `event-data` tag on `#system` PRIVMSGs now carry the
->   canonical 5-field envelope `{type, channel, nick, data, timestamp}`.
->   `ServerLink._handle_sevent` sniffs the shape so 9.5 receivers
->   tolerate both envelope (9.5+ peers) and legacy data-only (≤9.4
->   peers); 9.5→9.4 emit breaks until peers upgrade. Internal change;
->   no new public symbols. See CHANGELOG `[9.5.0a2]` § Notes.
-> - **9.5.0a3 (planned):** bot-CAP behavior, `EVENTSUB`/`EVENTUNSUB`
->   handlers, the in-memory `SubscriptionRegistry`, and `EVENTPUB`
->   handler. Daemon starts advertising `BOT_CAP` in `CAP LS` output.
-> - **9.5.0 (final):** `webhook_port` no longer bound; `cli.md` /
->   `deployment.md` updated; this block flips from "phased rollout" to
->   "current," and the version-history table picks up a 9.5.0 row.
->
-> Wire format and verb syntax are specified in
-> [`docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`](superpowers/specs/2026-05-01-bot-extension-api-design.md);
-> a quick reference for bot authors is at [`docs/extension-api.md`](extension-api.md).
-> Tracking issue: [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15).
+**Bot extension API (shipped in 9.5.0):**
+
+- `agentirc.protocol` exports the `Event` dataclass, the `EventType`
+  enum (`StrEnum`), 20 per-type `EVENT_TYPE_*` string constants, the
+  `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` / `EVENTPUB` verb
+  constants, the `SEVENT` federation verb constant, and the
+  `BOT_CAP = "agentirc.io/bot"` capability identifier.
+- `ServerConfig.event_subscription_queue_max: int = 1024` — per-subscription
+  bounded queue depth; recognised by `ServerConfig.from_yaml` and
+  `agentirc.cli._resolve_config()`.
+- The IRCv3 `agentirc.io/bot` capability gates four behaviours when
+  negotiated via `CAP REQ`: silent JOIN/PART/QUIT broadcasts to other
+  channel members, no auto-op on a fresh-channel first-joiner, `+`
+  prefix in NAMES output, `B` flag in WHO output. Reserved keys in
+  `Event.data` (`_`-prefixed) are stripped at emit time and reconstructed
+  by the receiver — peers cannot inject `_render` etc. across the wire.
+- `EVENTSUB <sub-id> [type=<glob>] [channel=<name>] [nick=<glob>]` opens
+  a streaming subscription whose matching events arrive as
+  `:server EVENT <sub-id> <type> <channel-or-*> <nick> :<base64-json-envelope>`
+  lines. Filters are AND-ed; type and nick accept `fnmatch`-style globs;
+  channel accepts an exact name, `*` (any channel including nick-scoped),
+  or empty (nick-scoped events only). Per-subscription queues default to
+  `event_subscription_queue_max=1024`; on overflow the server emits
+  `EVENTERR <sub-id> :backpressure-overflow` and drops the subscription
+  (the connection itself stays open).
+- `EVENTPUB <type> <channel-or-*> :<base64-json-data>` lets a bot emit
+  a custom-typed event back into the stream. The type must match
+  `EVENT_TYPE_RE` (dotted lowercase, ≥1 dot — single-segment names like
+  `message` and `topic` are reserved for built-ins). The server fills
+  `nick` from the bot's connection nick (not spoofable) and `timestamp`
+  from `time.time()` (so federation peers see consistent clocks).
+- **`webhook_port` is accepted in config but no longer bound.** The
+  field stays in `ServerConfig` for backward compat with culture's
+  `~/.culture/server.yaml`, but `IRCd.start()` no longer instantiates
+  the HTTP listener. Consumers that need webhook→bot dispatch host their
+  own listener (see [`deployment.md`](deployment.md)).
+
+Wire format and verb syntax are specified in
+[`docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`](superpowers/specs/2026-05-01-bot-extension-api-design.md);
+a quick reference for bot authors is at [`docs/extension-api.md`](extension-api.md).
+Tracking issue: [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15).
 
 ## Semver contract
 
@@ -272,6 +285,10 @@ there for consistency.
 | 9.2.0 | 2026-05-01 | Real CLI dispatch, `agentirc.protocol`, `agentirc.client`. New verbs: `serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`. |
 | 9.3.0 | 2026-05-01 | Test suite (315 tests, `pytest -n auto` in ~29s) — internal. |
 | 9.4.0 | 2026-05-01 | `ServerConfig.from_yaml(path)` classmethod. CLI flags now overlay YAML config (precedence: CLI > YAML > built-in defaults). Three docs published: `api-stability.md`, `cli.md`, `deployment.md`. New runtime dep: `pyyaml>=6.0`. |
+| 9.4.1 | 2026-05-01 | Docs-only follow-up; functionally identical to 9.4.0. |
+| 9.5.0a1 | 2026-05-02 | **Bot extension API — declarations slice.** Public `agentirc.protocol` exports: `Event`, `EventType` (now `StrEnum`), 20 `EVENT_TYPE_*` constants, `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR` / `EVENTPUB` verb constants, `BOT_CAP`. New `ServerConfig.event_subscription_queue_max: int = 1024`. Symbols importable but inert. |
+| 9.5.0a2 | 2026-05-02 | **Bot extension API — wire-format slice.** SEVENT and IRCv3 `event-data` tag now carry the canonical 5-field envelope `{type, channel, nick, data, timestamp}`. `_handle_sevent` sniffs the shape so 9.5 receivers tolerate ≤9.4 legacy peers (asymmetric: 9.5→9.4 emit breaks until peers upgrade). Added `agentirc.protocol.SEVENT`. Internal-only changes; no new public-API symbols beyond `SEVENT`. |
+| 9.5.0 | 2026-05-02 | **Bot extension API — final.** `agentirc.io/bot` IRCv3 capability gates silent JOIN/PART/QUIT broadcasts, no auto-op on fresh channels, `+` prefix in NAMES, `B` flag in WHO. New IRC verbs: `EVENTSUB` / `EVENTUNSUB` / `EVENTPUB` (handlers + per-subscription bounded queues; `EVENT` / `EVENTERR` server→client). `webhook_port` no longer bound by `IRCd.start()` (field stays for backward compat). Closes [#15](https://github.com/agentculture/agentirc/issues/15). |
 
 ## Distribution
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ set (the *start flags*) plus a per-verb extra:
 | `--host HOST` | `0.0.0.0` | Bind address. |
 | `--port PORT` | `6667` | Bind TCP port. `0` requests an OS-assigned port; in `start` mode the daemon won't write a `.port` file when `--port 0` is used, so `agentirc status` reports only the PID. |
 | `--link SPEC` | none | S2S link, format `name:host:port:password[:trust]`. Repeatable. |
-| `--webhook-port PORT` | `7680` | HTTP port for bot webhooks. Inert until a bot harness is wired in. |
+| `--webhook-port PORT` | `7680` | Accepted for backward compatibility; **not bound by `agentirc`** as of 9.5.0. The field is preserved so culture's `~/.culture/server.yaml` keeps loading unchanged; consumers (e.g. culture) host their own webhook listener if they need one. |
 | `--data-dir PATH` | `~/.culture/data` | Directory for persistent storage (history.db, etc.). |
 | `--config PATH` | `~/.culture/server.yaml` | YAML file to load defaults from. |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -163,8 +163,16 @@ ignores keys it doesn't own (`supervisor`, `agents`, `webhooks`,
 `buffer_size`, `poll_interval`, `sleep_start`, `sleep_end`, and the
 `server.archived*` fields culture uses for its server-archival
 tracking). Culture's loader treats agentirc-only keys (`links`,
-`webhook_port`, `data_dir`, `system_bots`) symmetrically. So one
+`webhook_port`, `data_dir`, `system_bots`,
+`event_subscription_queue_max`) symmetrically. So one
 `server.yaml` can drive both daemons.
+
+**As of 9.5.0, `agentirc` does not bind `webhook_port`.** The field
+stays in `ServerConfig` so existing `~/.culture/server.yaml` files
+keep loading without errors, but `IRCd.start()` no longer
+instantiates an HTTP listener. Consumers that need webhook→bot
+dispatch (notably culture) host their own listener. The field will
+be removed in a future major bump (10.0.0).
 
 ## Log rotation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentirc-cli"
-version = "9.5.0a2"
+version = "9.5.0"
 description = "Agent-friendly IRCd: server core for AI agent meshes"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_bot_capability.py
+++ b/tests/test_bot_capability.py
@@ -1,0 +1,204 @@
+"""Tests for the ``agentirc.io/bot`` IRCv3 capability (9.5.0).
+
+Spec: ``docs/superpowers/specs/2026-05-01-bot-extension-api-design.md``
+§ Decision C. The capability gates four behaviours when negotiated:
+
+- silent JOIN/PART/QUIT broadcasts (other channel members see nothing)
+- no auto-op on first-joiner of a fresh channel
+- ``+`` prefix in NAMES output
+- ``B`` flag in WHO output
+
+These tests exercise each behaviour against the running daemon. ``CAP``
+processing has no registration gate so we register first via ``make_client``
+and then negotiate the capability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+async def _negotiate_bot_cap(client) -> None:
+    """Send ``CAP REQ :agentirc.io/bot`` and drain the ACK."""
+    await client.send("CAP REQ :agentirc.io/bot")
+    await client.recv_until("CAP")
+
+
+@pytest.mark.asyncio
+async def test_cap_ls_advertises_bot_capability(make_client):
+    """CAP LS lists both ``message-tags`` and ``agentirc.io/bot``."""
+    c = await make_client("testserv-prober", "prober")
+    await c.send("CAP LS")
+    line = await c.recv_until("CAP")
+    # CAP LS reply lists the supported caps. Locked-in semver-stable token.
+    assert "message-tags" in line
+    assert "agentirc.io/bot" in line
+
+
+@pytest.mark.asyncio
+async def test_cap_req_bot_acked(make_client):
+    """``CAP REQ :agentirc.io/bot`` is ACKed and adds the cap to the connection."""
+    c = await make_client("testserv-asker", "asker")
+    await c.send("CAP REQ :agentirc.io/bot")
+    line = await c.recv_until("CAP")
+    assert " ACK :agentirc.io/bot" in line
+
+
+@pytest.mark.asyncio
+async def test_cap_req_bot_with_message_tags_acked(make_client):
+    """Both caps can be requested in one CAP REQ."""
+    c = await make_client("testserv-multi", "multi")
+    await c.send("CAP REQ :agentirc.io/bot message-tags")
+    line = await c.recv_until("CAP")
+    assert " ACK :" in line
+    assert "agentirc.io/bot" in line
+    assert "message-tags" in line
+
+
+@pytest.mark.asyncio
+async def test_cap_req_unknown_cap_naked(make_client):
+    """An unknown cap NAKs the entire request — atomic semantics."""
+    c = await make_client("testserv-bad", "bad")
+    await c.send("CAP REQ :totally-not-a-cap")
+    line = await c.recv_until("CAP")
+    assert " NAK :" in line
+
+
+@pytest.mark.asyncio
+async def test_silent_join_no_broadcast_to_other_members(server, make_client):
+    """A bot-CAP client joining a channel does not produce a JOIN line for other members."""
+    # Human observer in #room first.
+    human = await make_client("testserv-alice", "alice")
+    await human.send("JOIN #room")
+    await human.recv_until("366")  # end of NAMES
+    await asyncio.sleep(0.05)
+    await human.recv_all(timeout=0.2)  # drain join-event PRIVMSGs etc.
+
+    # Bot client registers, negotiates CAP, then joins #room.
+    bot = await make_client("testserv-bob", "bob")
+    await _negotiate_bot_cap(bot)
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+    await bot.send("JOIN #room")
+    # The bot doesn't receive a JOIN echo either (broadcast suppressed for
+    # the whole loop including self), but it still gets topic + NAMES so
+    # 366 (end of NAMES) is the success signal.
+    await bot.recv_until("366")
+    await asyncio.sleep(0.2)
+
+    # Human should NOT see a JOIN line from the bot in #room.
+    # recv_all returns a list of received lines; recv() chunks may contain
+    # multiple wire lines separated by \r\n, so split each chunk too.
+    received = await human.recv_all(timeout=0.5)
+    raw_lines = []
+    for chunk in received:
+        raw_lines.extend(chunk.split("\r\n"))
+    for raw in raw_lines:
+        # The human gets system PRIVMSGs surfaced from #system events
+        # (which include "user.join" event-data). Those go to #system,
+        # not #room. We check specifically for a wire-level
+        # `:testserv-bob ... JOIN #room` line — that's what silent CAP
+        # suppresses.
+        assert not (raw.startswith(":testserv-bob") and "JOIN #room" in raw), (
+            f"Bot's JOIN leaked to human despite agentirc.io/bot CAP: {raw!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_bot_no_auto_op_on_fresh_channel(server, make_client):
+    """A bot joining an empty channel does NOT become op; the next human does."""
+    bot = await make_client("testserv-mybot", "mybot")
+    await _negotiate_bot_cap(bot)
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+    await bot.send("JOIN #brandnewroom")
+    await bot.recv_until("366")
+    await asyncio.sleep(0.05)
+
+    channel = server.channels.get("#brandnewroom")
+    assert channel is not None
+    bot_client = server.clients.get("testserv-mybot")
+    assert bot_client is not None
+    # Bot is in the channel...
+    assert bot_client in channel.members
+    # ...but is NOT op.
+    assert bot_client not in channel.operators
+
+    # A human joins; they become op (first non-bot local joiner).
+    human = await make_client("testserv-alice", "alice")
+    await human.send("JOIN #brandnewroom")
+    await human.recv_until("366")
+    await asyncio.sleep(0.05)
+
+    human_client = server.clients.get("testserv-alice")
+    assert human_client is not None
+    assert human_client in channel.operators
+
+
+@pytest.mark.asyncio
+async def test_names_prefixes_bot_with_plus(server, make_client):
+    """NAMES output renders bot-CAP members with the ``+`` prefix."""
+    bot = await make_client("testserv-bottie", "bottie")
+    await _negotiate_bot_cap(bot)
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+    await bot.send("JOIN #lobby")
+    await bot.recv_until("366")
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+
+    human = await make_client("testserv-watcher2", "watcher2")
+    await human.send("JOIN #lobby")
+    names_block = await human.recv_until("366")
+    # The human's NAMES list should show the bot prefixed with +.
+    assert "+testserv-bottie" in names_block, (
+        f"Bot did not render with `+` prefix in NAMES: {names_block!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_who_marks_bot_with_b_flag(server, make_client):
+    """WHO output's user-modes column includes ``B`` for bot-CAP clients."""
+    bot = await make_client("testserv-flagged", "flagged")
+    await _negotiate_bot_cap(bot)
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+    await bot.send("JOIN #whotest")
+    await bot.recv_until("366")
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+
+    human = await make_client("testserv-watcher", "watcher")
+    await human.send("WHO #whotest")
+    who_block = await human.recv_until("315")  # RPL_ENDOFWHO
+    bot_who = next(
+        (ln for ln in who_block.split("\r\n") if "testserv-flagged" in ln and "352" in ln),
+        None,
+    )
+    assert bot_who is not None, f"No WHO 352 line for bot: {who_block!r}"
+    # The H flag is always present (Here); B is the agentirc bot extension.
+    # WHO format puts flags as a single token: e.g. "HB", "HB@", "H@".
+    assert "HB" in bot_who, (
+        f"Bot WHO line missing `B` flag: {bot_who!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_human_who_has_no_b_flag(server, make_client):
+    """A non-bot client's WHO output does NOT include ``B``."""
+    human = await make_client("testserv-onlyhuman", "onlyhuman")
+    await human.send("JOIN #whotest2")
+    await human.recv_until("366")
+    await asyncio.sleep(0.05)
+    await human.recv_all(timeout=0.2)
+    await human.send("WHO #whotest2")
+    who_block = await human.recv_until("315")
+    alice_who = next(
+        (ln for ln in who_block.split("\r\n") if "testserv-onlyhuman" in ln and "352" in ln),
+        None,
+    )
+    assert alice_who is not None
+    # `H@` (Here + op) is fine; `HB` is not.
+    assert "HB" not in alice_who, f"Human WHO unexpectedly has B flag: {alice_who!r}"

--- a/tests/test_event_subscriptions.py
+++ b/tests/test_event_subscriptions.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 from agentirc.protocol import Event, EventType
+
+if TYPE_CHECKING:
+    from agentirc.client import Client
 
 
 async def _make_bot(make_client, nick: str, user: str):
@@ -256,7 +260,7 @@ async def test_subscription_registry_backpressure_drops_sub(server):
     sent_lines: list[str] = []
 
     class FakeClient:
-        async def send_raw(self, line: str) -> None:
+        async def send_raw(self, line: str) -> None:  # NOSONAR python:S7503: must be async to duck-type Client.send_raw which the registry awaits
             sent_lines.append(line)
 
         @property
@@ -265,13 +269,13 @@ async def test_subscription_registry_backpressure_drops_sub(server):
 
         nick = "testserv-fake"
 
-    registry = SubscriptionRegistry(queue_max=2)
-    fake = FakeClient()
     # FakeClient duck-types Client (send_raw, nick, server) — the registry
-    # only touches those attributes. Type-ignore on the call sites where
-    # a strict checker (SonarCloud python:S5655) would otherwise flag the
-    # scaffold as a type mismatch.
-    sub = registry.add(fake, "subA", type_glob="*")  # type: ignore[arg-type]
+    # only touches those attributes. ``cast`` tells static analysers
+    # (mypy / SonarCloud python:S5655) to treat the scaffold as a Client at
+    # the call sites; it is a no-op at runtime.
+    registry = SubscriptionRegistry(queue_max=2)
+    fake = cast("Client", FakeClient())
+    sub = registry.add(fake, "subA", type_glob="*")
     assert sub is not None
 
     # Cancel the drain task immediately so the queue stays full.
@@ -289,7 +293,7 @@ async def test_subscription_registry_backpressure_drops_sub(server):
     assert len(overflows) == 1
     assert "EVENTERR subA :backpressure-overflow" in overflows[0]
     # Subscription is gone from the registry after the drop.
-    assert registry.get(fake, "subA") is None  # type: ignore[arg-type]
+    assert registry.get(fake, "subA") is None
 
 
 def test_subscription_filter_matches_unit():

--- a/tests/test_event_subscriptions.py
+++ b/tests/test_event_subscriptions.py
@@ -176,6 +176,55 @@ async def test_eventsub_unknown_filter(server, make_client):
 
 
 @pytest.mark.asyncio
+async def test_eventsub_duplicate_filter_rejected(server, make_client):
+    """Per-spec, each filter parameter appears at most once."""
+    bot = await _make_bot(make_client, "testserv-dupfilt", "dupfilt")
+    await bot.send("EVENTSUB sub1 type=user.join type=user.part")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :duplicate-filter type" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_invalid_channel_filter_rejected(server, make_client):
+    """`channel=room` (no `#`) is rejected so subscribers don't silently miss matches."""
+    bot = await _make_bot(make_client, "testserv-noprefix", "noprefix")
+    await bot.send("EVENTSUB sub1 channel=room")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :invalid-channel-filter room" in line
+
+
+@pytest.mark.asyncio
+async def test_eventunsub_cap_gated(server, make_client):
+    """A non-bot client's EVENTUNSUB is rejected with bot-capability-required.
+
+    Regression guard for PR #20 review (Copilot 3176303659): EVENTUNSUB must
+    enforce the same CAP gate as EVENTSUB so the wire contract stays
+    consistent.
+    """
+    c = await make_client("testserv-bareuser", "bareuser")
+    await c.send("EVENTUNSUB sub1")
+    line = await c.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :bot-capability-required" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_requires_registration(server, make_client):
+    """An unregistered (no NICK/USER) connection is rejected.
+
+    Regression guard for PR #20 review (Copilot 3176303652): a CAP-only
+    socket must not be able to subscribe before claiming an identity.
+    """
+    # ``make_client()`` without args opens a TCP connection but doesn't
+    # send NICK/USER, so the server still considers the client unregistered.
+    c = await make_client()
+    await c.send("CAP REQ :agentirc.io/bot")
+    await c.recv_until("CAP")
+    await c.send("EVENTSUB sub1 type=*")
+    line = await c.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :not-registered" in line
+
+
+@pytest.mark.asyncio
 async def test_eventsub_disconnect_cleanup(server, make_client):
     """Closing the connection cancels all subscriptions for that client."""
     bot = await _make_bot(make_client, "testserv-leaver", "leaver")
@@ -218,7 +267,11 @@ async def test_subscription_registry_backpressure_drops_sub(server):
 
     registry = SubscriptionRegistry(queue_max=2)
     fake = FakeClient()
-    sub = registry.add(fake, "subA", type_glob="*")
+    # FakeClient duck-types Client (send_raw, nick, server) — the registry
+    # only touches those attributes. Type-ignore on the call sites where
+    # a strict checker (SonarCloud python:S5655) would otherwise flag the
+    # scaffold as a type mismatch.
+    sub = registry.add(fake, "subA", type_glob="*")  # type: ignore[arg-type]
     assert sub is not None
 
     # Cancel the drain task immediately so the queue stays full.
@@ -236,11 +289,10 @@ async def test_subscription_registry_backpressure_drops_sub(server):
     assert len(overflows) == 1
     assert "EVENTERR subA :backpressure-overflow" in overflows[0]
     # Subscription is gone from the registry after the drop.
-    assert registry.get(fake, "subA") is None
+    assert registry.get(fake, "subA") is None  # type: ignore[arg-type]
 
 
-@pytest.mark.asyncio
-async def test_subscription_filter_matches_unit():
+def test_subscription_filter_matches_unit():
     """Unit-level checks for the AND-ed glob/exact filter logic."""
     from agentirc._internal.event_subscriptions import (
         CHANNEL_ANY,

--- a/tests/test_event_subscriptions.py
+++ b/tests/test_event_subscriptions.py
@@ -1,0 +1,279 @@
+"""Tests for the EVENTSUB / EVENTUNSUB / EVENT / EVENTERR verbs (9.5.0).
+
+Spec: ``docs/superpowers/specs/2026-05-01-bot-extension-api-design.md``
+§ Decision B. Bots negotiate ``agentirc.io/bot`` and stream events with
+AND-ed ``type=`` / ``channel=`` / ``nick=`` filters; backpressure on
+overflow drops the subscription.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from agentirc.protocol import Event, EventType
+
+
+async def _make_bot(make_client, nick: str, user: str):
+    """Connect, register, negotiate ``agentirc.io/bot``, drain the ACK."""
+    c = await make_client(nick, user)
+    await c.send("CAP REQ :agentirc.io/bot")
+    await c.recv_until("CAP")
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)
+    return c
+
+
+@pytest.mark.asyncio
+async def test_eventsub_requires_bot_cap(make_client):
+    """A non-bot client's EVENTSUB is rejected with bot-capability-required."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("EVENTSUB sub1 type=user.join")
+    line = await c.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :bot-capability-required" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_happy_path(server, make_client):
+    """A bot subscribed to ``user.join`` receives one EVENT line per matching event."""
+    bot = await _make_bot(make_client, "testserv-watcher", "watcher")
+    await bot.send("EVENTSUB sub1 type=user.join channel=#room")
+    await asyncio.sleep(0.05)
+
+    # Trigger a user.join event on #room.
+    other = await make_client("testserv-newbie", "newbie")
+    await other.send("JOIN #room")
+    await other.recv_until("366")
+    await asyncio.sleep(0.1)
+
+    # Bot should receive an EVENT line for the join.
+    block = await bot.recv_until("EVENT")
+    line = next(ln for ln in block.split("\r\n") if " EVENT sub1 " in ln)
+    # Wire format: :server EVENT <sub-id> <type> <channel-or-*> <nick> :<b64>
+    parts = line.split(" ", 5)
+    assert parts[1] == "EVENT"
+    assert parts[2] == "sub1"
+    assert parts[3] == "user.join"
+    assert parts[4] == "#room"
+    assert parts[5].startswith("testserv-newbie ")
+
+    # The trailing base64 decodes to the canonical 5-field envelope.
+    b64 = line.split(":", 2)[-1]
+    envelope = json.loads(base64.b64decode(b64))
+    assert envelope["type"] == "user.join"
+    assert envelope["channel"] == "#room"
+    assert envelope["nick"] == "testserv-newbie"
+
+
+@pytest.mark.asyncio
+async def test_eventsub_filter_type_glob(server, make_client):
+    """``type=user.*`` matches user.join, user.part, etc."""
+    bot = await _make_bot(make_client, "testserv-globber", "globber")
+    await bot.send("EVENTSUB sub1 type=user.* channel=#globroom")
+    await asyncio.sleep(0.05)
+
+    other = await make_client("testserv-mover", "mover")
+    await other.send("JOIN #globroom")
+    await other.recv_until("366")
+    await asyncio.sleep(0.05)
+    await other.send("PART #globroom")
+    await asyncio.sleep(0.1)
+
+    # Bot should receive both user.join and user.part EVENT lines.
+    received_types = []
+    chunks = await bot.recv_all(timeout=0.5)
+    for chunk in chunks:
+        for line in chunk.split("\r\n"):
+            if " EVENT sub1 " in line:
+                received_types.append(line.split(" ")[3])
+    assert "user.join" in received_types
+    assert "user.part" in received_types
+
+
+@pytest.mark.asyncio
+async def test_eventsub_filter_channel_exact_match(server, make_client):
+    """``channel=#a`` does NOT match events on ``#b``."""
+    bot = await _make_bot(make_client, "testserv-channelbot", "channelbot")
+    await bot.send("EVENTSUB sub1 type=user.join channel=#alpha")
+    await asyncio.sleep(0.05)
+
+    other = await make_client("testserv-betatester", "betatester")
+    await other.send("JOIN #beta")
+    await other.recv_until("366")
+    await asyncio.sleep(0.2)
+
+    # Bot should receive nothing for sub1.
+    chunks = await bot.recv_all(timeout=0.3)
+    for chunk in chunks:
+        for line in chunk.split("\r\n"):
+            assert " EVENT sub1 " not in line, (
+                f"Channel filter leaked event from #beta: {line!r}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_eventunsub_stops_stream(server, make_client):
+    """After EVENTUNSUB, no further EVENT lines arrive for that sub-id."""
+    bot = await _make_bot(make_client, "testserv-unsubber", "unsubber")
+    await bot.send("EVENTSUB sub1 type=user.join channel=#unsubroom")
+    await asyncio.sleep(0.05)
+
+    other = await make_client("testserv-first", "first")
+    await other.send("JOIN #unsubroom")
+    await other.recv_until("366")
+    await asyncio.sleep(0.1)
+    # Drain the first event.
+    await bot.recv_until("EVENT")
+
+    await bot.send("EVENTUNSUB sub1")
+    await asyncio.sleep(0.05)
+
+    # Drain anything in flight, then trigger another join.
+    await bot.recv_all(timeout=0.2)
+    other2 = await make_client("testserv-second", "second")
+    await other2.send("JOIN #unsubroom")
+    await other2.recv_until("366")
+    await asyncio.sleep(0.2)
+
+    chunks = await bot.recv_all(timeout=0.3)
+    for chunk in chunks:
+        for line in chunk.split("\r\n"):
+            assert " EVENT sub1 " not in line, f"EVENTUNSUB didn't stop stream: {line!r}"
+
+
+@pytest.mark.asyncio
+async def test_eventsub_sub_id_collision(server, make_client):
+    """Re-using an active sub-id returns ``EVENTERR :sub-id-in-use``."""
+    bot = await _make_bot(make_client, "testserv-dup", "dup")
+    await bot.send("EVENTSUB sub1 type=*")
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+
+    await bot.send("EVENTSUB sub1 type=user.join")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :sub-id-in-use" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_invalid_sub_id_format(server, make_client):
+    """Sub-id must match ``[A-Za-z0-9._:-]{1,32}``."""
+    bot = await _make_bot(make_client, "testserv-invalid", "invalid")
+    await bot.send("EVENTSUB sub#bad type=*")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR sub#bad :invalid-sub-id" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_unknown_filter(server, make_client):
+    """Unknown filter keys are rejected."""
+    bot = await _make_bot(make_client, "testserv-bogus", "bogus")
+    await bot.send("EVENTSUB sub1 bogus=value")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR sub1 :unknown-filter bogus" in line
+
+
+@pytest.mark.asyncio
+async def test_eventsub_disconnect_cleanup(server, make_client):
+    """Closing the connection cancels all subscriptions for that client."""
+    bot = await _make_bot(make_client, "testserv-leaver", "leaver")
+    await bot.send("EVENTSUB sub1 type=*")
+    await asyncio.sleep(0.05)
+
+    bot_client = server.clients.get("testserv-leaver")
+    assert bot_client is not None
+    assert server.subscription_registry.list_for_client(bot_client)
+
+    await bot.close()
+    # Give the disconnect path time to run.
+    for _ in range(50):
+        if not server.subscription_registry.list_for_client(bot_client):
+            break
+        await asyncio.sleep(0.05)
+    assert not server.subscription_registry.list_for_client(bot_client), (
+        "Subscription leaked after client disconnect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_subscription_registry_backpressure_drops_sub(server):
+    """Filling the queue past its bound triggers EVENTERR :backpressure-overflow."""
+    # We exercise the registry directly with a fake client to avoid the
+    # need for a real TCP queue depth (StreamWriter has no public maxsize).
+    from agentirc._internal.event_subscriptions import SubscriptionRegistry
+
+    sent_lines: list[str] = []
+
+    class FakeClient:
+        async def send_raw(self, line: str) -> None:
+            sent_lines.append(line)
+
+        @property
+        def server(self):  # for the drain task's name
+            return server
+
+        nick = "testserv-fake"
+
+    registry = SubscriptionRegistry(queue_max=2)
+    fake = FakeClient()
+    sub = registry.add(fake, "subA", type_glob="*")
+    assert sub is not None
+
+    # Cancel the drain task immediately so the queue stays full.
+    if sub.drain_task is not None:
+        sub.drain_task.cancel()
+
+    base = Event(type=EventType.JOIN, channel="#x", nick="alice", data={})
+    # First two fill the queue.
+    await registry.dispatch(base)
+    await registry.dispatch(base)
+    # Third overflows and triggers the backpressure drop.
+    await registry.dispatch(base)
+
+    overflows = [ln for ln in sent_lines if "backpressure-overflow" in ln]
+    assert len(overflows) == 1
+    assert "EVENTERR subA :backpressure-overflow" in overflows[0]
+    # Subscription is gone from the registry after the drop.
+    assert registry.get(fake, "subA") is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_filter_matches_unit():
+    """Unit-level checks for the AND-ed glob/exact filter logic."""
+    from agentirc._internal.event_subscriptions import (
+        CHANNEL_ANY,
+        CHANNEL_NICK_SCOPED_ONLY,
+        Subscription,
+    )
+
+    e_join = Event(type="user.join", channel="#room", nick="alice", data={})
+    e_part = Event(type="user.part", channel="#room", nick="alice", data={})
+    e_global = Event(type="server.wake", channel=None, nick="system", data={})
+
+    # type-glob match.
+    sub = Subscription(sub_id="s1", type_glob="user.*")
+    assert sub.matches(e_join)
+    assert sub.matches(e_part)
+    assert not sub.matches(e_global)
+
+    # channel exact match.
+    sub2 = Subscription(sub_id="s2", channel="#room")
+    assert sub2.matches(e_join)
+    assert not sub2.matches(e_global)
+
+    # channel="*" matches everything including None.
+    sub3 = Subscription(sub_id="s3", channel=CHANNEL_ANY)
+    assert sub3.matches(e_join)
+    assert sub3.matches(e_global)
+
+    # channel="" matches only nick-scoped events.
+    sub4 = Subscription(sub_id="s4", channel=CHANNEL_NICK_SCOPED_ONLY)
+    assert not sub4.matches(e_join)
+    assert sub4.matches(e_global)
+
+    # nick-glob match.
+    sub5 = Subscription(sub_id="s5", nick_glob="ali*")
+    assert sub5.matches(e_join)
+    assert not sub5.matches(e_global)

--- a/tests/test_eventpub.py
+++ b/tests/test_eventpub.py
@@ -1,0 +1,194 @@
+"""Tests for the EVENTPUB verb (9.5.0).
+
+Spec: ``docs/superpowers/specs/2026-05-01-bot-extension-api-design.md``
+§ Decision E. Symmetric to EVENTSUB — bots emit custom-typed events back
+into the stream. Server-side validation enforces ``EVENT_TYPE_RE`` and
+sets ``nick`` and ``timestamp`` so bots cannot spoof the actor or the
+wall-clock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+
+async def _make_bot(make_client, nick: str, user: str):
+    c = await make_client(nick, user)
+    await c.send("CAP REQ :agentirc.io/bot")
+    await c.recv_until("CAP")
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)
+    return c
+
+
+def _b64_json(payload: dict) -> str:
+    return base64.b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_eventpub_requires_bot_cap(server, make_client):
+    """A non-bot client's EVENTPUB is rejected."""
+    c = await make_client("testserv-alice", "alice")
+    await c.send("JOIN #room")
+    await c.recv_until("366")
+    await asyncio.sleep(0.05)
+    await c.recv_all(timeout=0.2)
+    payload = _b64_json({"text": "hello"})
+    await c.send(f"EVENTPUB welcome.greeted #room :{payload}")
+    line = await c.recv_until("EVENTERR")
+    assert "EVENTERR welcome.greeted :bot-capability-required" in line
+
+
+@pytest.mark.asyncio
+async def test_eventpub_happy_path(server, make_client):
+    """Bot A emits → Bot B subscribed to the matching type receives one EVENT line."""
+    bot_a = await _make_bot(make_client, "testserv-emitter", "emitter")
+    bot_b = await _make_bot(make_client, "testserv-listener", "listener")
+
+    # Pre-create #emitroom so EVENTPUB doesn't hit the no-such-channel guard.
+    server.get_or_create_channel("#emitroom")
+
+    await bot_b.send("EVENTSUB sub1 type=welcome.greeted")
+    await asyncio.sleep(0.05)
+    await bot_b.recv_all(timeout=0.2)
+
+    payload = _b64_json({"greeted_user": "newbie"})
+    await bot_a.send(f"EVENTPUB welcome.greeted #emitroom :{payload}")
+    await asyncio.sleep(0.1)
+
+    block = await bot_b.recv_until("EVENT")
+    line = next(ln for ln in block.split("\r\n") if " EVENT sub1 " in ln)
+    parts = line.split(" ", 5)
+    assert parts[1] == "EVENT"
+    assert parts[2] == "sub1"
+    assert parts[3] == "welcome.greeted"
+    assert parts[4] == "#emitroom"
+    # nick is server-set from emitter's connection nick (NOT spoofable).
+    assert parts[5].startswith("testserv-emitter ")
+
+    # Decoded envelope reflects server-set nick + greeted_user data.
+    b64 = line.split(":", 2)[-1]
+    envelope = json.loads(base64.b64decode(b64))
+    assert envelope["type"] == "welcome.greeted"
+    assert envelope["channel"] == "#emitroom"
+    assert envelope["nick"] == "testserv-emitter"
+    assert envelope["data"]["greeted_user"] == "newbie"
+
+
+@pytest.mark.asyncio
+async def test_eventpub_invalid_type_rejected(server, make_client):
+    """Single-segment type fails ``EVENT_TYPE_RE`` (which requires a dot)."""
+    bot = await _make_bot(make_client, "testserv-spoofer", "spoofer")
+    payload = _b64_json({"text": "fake"})
+    # Single-segment "message" is reserved for built-in vocabulary.
+    await bot.send(f"EVENTPUB message * :{payload}")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR message :invalid-type" in line
+
+
+@pytest.mark.asyncio
+async def test_eventpub_no_such_channel(server, make_client):
+    """Channel-scoped emission to a non-existent channel is rejected."""
+    bot = await _make_bot(make_client, "testserv-roomless", "roomless")
+    payload = _b64_json({"text": "lost"})
+    await bot.send(f"EVENTPUB welcome.greeted #nowhere :{payload}")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR welcome.greeted :no-such-channel" in line
+
+
+@pytest.mark.asyncio
+async def test_eventpub_invalid_payload(server, make_client):
+    """Non-JSON-object payload is rejected."""
+    bot = await _make_bot(make_client, "testserv-broken", "broken")
+    server.get_or_create_channel("#broken")
+    # Encode a JSON list instead of a dict.
+    bad = base64.b64encode(b"[1,2,3]").decode("ascii")
+    await bot.send(f"EVENTPUB welcome.greeted #broken :{bad}")
+    line = await bot.recv_until("EVENTERR")
+    assert "EVENTERR welcome.greeted :invalid-payload" in line
+
+
+@pytest.mark.asyncio
+async def test_eventpub_strips_underscore_keys(server, make_client):
+    """Server-internal ``_render`` and other ``_``-prefixed keys are stripped."""
+    bot_a = await _make_bot(make_client, "testserv-injector", "injector")
+    bot_b = await _make_bot(make_client, "testserv-observer", "observer")
+    server.get_or_create_channel("#stripsroom")
+
+    await bot_b.send("EVENTSUB sub1 type=welcome.greeted")
+    await asyncio.sleep(0.05)
+    await bot_b.recv_all(timeout=0.2)
+
+    payload = _b64_json(
+        {
+            "text": "hi",
+            "_render": "ATTACKER-CONTROLLED",
+            "_origin": "spoofed",
+            "_secret": "leak",
+        }
+    )
+    await bot_a.send(f"EVENTPUB welcome.greeted #stripsroom :{payload}")
+    await asyncio.sleep(0.1)
+
+    block = await bot_b.recv_until("EVENT")
+    line = next(ln for ln in block.split("\r\n") if " EVENT sub1 " in ln)
+    b64 = line.split(":", 2)[-1]
+    envelope = json.loads(base64.b64decode(b64))
+    # `text` survives, all `_`-keys do not.
+    assert envelope["data"]["text"] == "hi"
+    assert "_render" not in envelope["data"]
+    assert "_secret" not in envelope["data"]
+    # `_origin` is also not in the public envelope (server adds it after
+    # encode for federation; the public-wire envelope strips at emit time).
+
+
+@pytest.mark.asyncio
+async def test_eventpub_reflexive_subscription(server, make_client):
+    """A bot subscribed to its own emitted type receives its own EVENT line."""
+    bot = await _make_bot(make_client, "testserv-mirror", "mirror")
+    server.get_or_create_channel("#mirrorroom")
+
+    await bot.send("EVENTSUB sub1 type=welcome.greeted")
+    await asyncio.sleep(0.05)
+    await bot.recv_all(timeout=0.2)
+
+    payload = _b64_json({"text": "self"})
+    await bot.send(f"EVENTPUB welcome.greeted #mirrorroom :{payload}")
+    await asyncio.sleep(0.1)
+
+    block = await bot.recv_until("EVENT")
+    line = next(ln for ln in block.split("\r\n") if " EVENT sub1 " in ln)
+    parts = line.split(" ", 5)
+    # Reflexive: the bot sees its own emission with its own nick.
+    assert parts[3] == "welcome.greeted"
+    assert parts[5].startswith("testserv-mirror ")
+
+
+@pytest.mark.asyncio
+async def test_eventpub_global_emission_with_star_channel(server, make_client):
+    """``EVENTPUB <type> * :<b64>`` emits a nick-scoped event (channel=None)."""
+    bot_a = await _make_bot(make_client, "testserv-broadcaster", "broadcaster")
+    bot_b = await _make_bot(make_client, "testserv-globlistener", "globlistener")
+
+    await bot_b.send("EVENTSUB sub1 type=server.heartbeat")
+    await asyncio.sleep(0.05)
+    await bot_b.recv_all(timeout=0.2)
+
+    payload = _b64_json({"uptime": 42})
+    await bot_a.send(f"EVENTPUB server.heartbeat * :{payload}")
+    await asyncio.sleep(0.1)
+
+    block = await bot_b.recv_until("EVENT")
+    line = next(ln for ln in block.split("\r\n") if " EVENT sub1 " in ln)
+    parts = line.split(" ", 5)
+    # Channel rendered as `*` for nick-scoped events.
+    assert parts[4] == "*"
+    b64 = line.split(":", 2)[-1]
+    envelope = json.loads(base64.b64decode(b64))
+    assert envelope["channel"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentirc-cli"
-version = "9.5.0a2"
+version = "9.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
## Summary

**Closes [#15](https://github.com/agentculture/agentirc/issues/15).** Final slice of the bot extension API rollout — Part 3 of 3, the meaty one.

| Slice | Version | What |
|---|---|---|
| Part 1 (#17) | 9.5.0a1 | Public declarations in `agentirc.protocol` |
| Part 2 (#18) | 9.5.0a2 | Wire-format envelope refactor + asymmetric sniff |
| **Part 3 (this PR)** | **9.5.0** | **Behaviour: bot CAP + new IRC verbs + webhook unbind** |

Unblocks [agentculture/culture#308](https://github.com/agentculture/culture/issues/308) Phase A2 (bot rewrite against the public API). After this lands and culture pins `agentirc-cli>=9.5,<10`, culture can delete its vendored `culture/agentirc/*` and shim `culture server` to `subprocess.run([\"agentirc\", *argv])`.

## What's in the PR

### Bot CAP (`agentirc.io/bot`)

- Advertised in `CAP LS`; accepted via `CAP REQ`.
- Four behaviours when negotiated:
  - **Silent JOIN/PART/QUIT** — other channel members see nothing on the wire. Channel membership IS added; events still fire (subscribers see them via `EVENTSUB`).
  - **No auto-op** — a bot joining an empty channel stays unprivileged; the next human becomes op.
  - **`+` prefix in NAMES** — voice-style mark in NAMES output (op `@` wins on conflict).
  - **`B` flag in WHO** — agentirc-extension flag in the user-modes column (composes with `H`/`@`/`+`).
- `VirtualClient` gains `caps = frozenset({\"agentirc.io/bot\", \"message-tags\"})` so the in-process system bot is treated identically to a real CAP-bot.

### `EVENTSUB` / `EVENTUNSUB` / `EVENT` / `EVENTERR`

- New internal module `agentirc/_internal/event_subscriptions.py` (`Subscription` + `SubscriptionRegistry`).
- `IRCd.emit_event` dispatches every event through the registry between `_dispatch_to_bots` and `_surface_event_privmsg`.
- Filter syntax: AND-ed `type=<glob>` / `channel=<name>` / `nick=<glob>`. Type and nick accept `fnmatch` globs; channel accepts exact name, `*` (any), or empty (nick-scoped only).
- Per-subscription bounded queue (default `ServerConfig.event_subscription_queue_max=1024`).
- **Backpressure:** queue overflow → `EVENTERR <sub-id> :backpressure-overflow` + subscription dropped. Connection stays open.
- **Disconnect cleanup:** `IRCd._remove_client` calls `registry.remove_client()` to cancel drain tasks.

### `EVENTPUB`

- Symmetric to `EVENTSUB` — bots emit custom-typed events back into the stream.
- **Type validated against `EVENT_TYPE_RE`** (`^[a-z][a-z0-9_-]*(\\.[a-z][a-z0-9_-]*)+$`). Single-segment names (`message`, `topic`) are reserved for built-in vocabulary.
- **Server-set `nick` and `timestamp`** — bots cannot spoof the actor or the wall-clock; federation peers see consistent values.
- **`_`-prefixed keys stripped** from the payload before emit (symmetric with the SEVENT decode-side strip from #18).

### `webhook_port` unbind

- `IRCd.start()` no longer instantiates `HttpListener`.
- `ServerConfig.webhook_port` stays — culture's `~/.culture/server.yaml` keeps loading unchanged.
- `agentirc/_internal/bots/http_listener.py` kept as no-op stub through 9.5.x; scheduled for deletion in 9.6.0.
- No runtime deprecation warning (would fire on every culture deployment until #308 cleanup — needless noise).

## Test plan

- [x] **28 new tests** across three files: `tests/test_bot_capability.py` (9), `tests/test_event_subscriptions.py` (11), `tests/test_eventpub.py` (8).
- [x] Full suite: **402 passed** (was 374 + 28 new). `pytest -n auto` in 32s.
- [x] CAP negotiation smoke: `CAP LS` advertises both `message-tags` and `agentirc.io/bot`; `CAP REQ` ACKs.
- [x] Silent JOIN: human observer in `#room` does NOT receive a `JOIN #room` line when a bot-CAP client joins the same channel.
- [x] No auto-op: bot joining empty `#brandnewroom` stays out of `channel.operators`; next human joiner is added.
- [x] NAMES `+` prefix and WHO `HB` flag verified against running daemon.
- [x] EVENTSUB happy path: glob filter + channel filter + decoded envelope match expected canonical shape.
- [x] Backpressure: queue depth 2, third dispatch triggers `EVENTERR :backpressure-overflow` and removes the subscription.
- [x] EVENTPUB rejection paths: missing CAP, invalid type, no-such-channel, invalid payload.
- [x] EVENTPUB happy path: server-set nick verified (bots cannot spoof).
- [x] EVENTPUB underscore strip: attacker-controlled `_render`/`_secret` do not survive emit.
- [x] EVENTPUB reflexive subscription: bot subscribed to its own emission receives the EVENT line back.
- [x] `agentirc version` reports `9.5.0`.
- [x] Portability lint clean (10 files checked).

## Out of scope

- **A2 culture-side bot rewrite** — culture's job; depends on this shipping.
- **`agentirc.skill.{Event, EventType}` re-export removal** — keep through 9.x; remove in 10.0.0.
- **`agentirc/_internal/bots/` synthesize-stub deletion** — defer to 9.6.0.
- **Wire-format quirk fixes** ([#7](https://github.com/agentculture/agentirc/issues/7), [#8](https://github.com/agentculture/agentirc/issues/8), [#9](https://github.com/agentculture/agentirc/issues/9)) — cross-repo coordination, separate PRs.
- **Callsite sweep** ([#11](https://github.com/agentculture/agentirc/issues/11)) — replace inline IRC verb literals with `agentirc.protocol.<NAME>`. Pure refactor; separate PR.

## Spec references

- Design spec: [`docs/superpowers/specs/2026-05-01-bot-extension-api-design.md`](https://github.com/agentculture/agentirc/blob/main/docs/superpowers/specs/2026-05-01-bot-extension-api-design.md)
- Bot-author quick reference: [`docs/extension-api.md`](https://github.com/agentculture/agentirc/blob/main/docs/extension-api.md)
- Public-API contract: [`docs/api-stability.md`](https://github.com/agentculture/agentirc/blob/feat/bot-extension-cap-and-verbs/docs/api-stability.md) (this PR flips the phased-rollout block to \"current\" and adds the 9.5.0 row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude